### PR TITLE
homescreen logic

### DIFF
--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -1,33 +1,23 @@
 import 'package:go_router/go_router.dart';
 import 'package:safespender/features/expenses/presentation/add_expense_screen.dart';
-import 'package:safespender/features/grocery/presentation/grocery_overview_screen.dart';
-import 'package:safespender/features/home/presentation/home_screen.dart';
-import 'package:safespender/features/settings/presentation/settings_screen.dart';
-import 'package:safespender/features/setup/presentation/setup_screen.dart';
+import 'package:safespender/features/navigation/presentation/main_shell_screen.dart';
 import 'package:safespender/features/purchase_check/presentation/purchase_check_screen.dart';
+import 'package:safespender/features/setup/presentation/setup_screen.dart';
 
 final GoRouter appRouter = GoRouter(
   initialLocation: '/setup',
   routes: [
     GoRoute(
       path: '/',
-      builder: (context, state) => const HomeScreen(),
-    ),
-    GoRoute(
-      path: '/settings',
-      builder: (context, state) => const SettingsScreen(),
-    ),
-    GoRoute(
-      path: '/addexpense',
-      builder: (context, state) => const AddExpenseScreen(),
-    ),
-    GoRoute(
-      path: '/groceryoverview',
-      builder: (context, state) => const GroceryOverviewScreen(),
+      builder: (context, state) => const MainShellScreen(),
     ),
     GoRoute(
       path: '/setup',
       builder: (context, state) => const SetupScreen(),
+    ),
+    GoRoute(
+      path: '/addexpense',
+      builder: (context, state) => const AddExpenseScreen(),
     ),
     GoRoute(
       path: '/purchase_check',

--- a/lib/features/home/domain/entities/category_summary.dart
+++ b/lib/features/home/domain/entities/category_summary.dart
@@ -1,0 +1,21 @@
+class CategorySummary {
+  const CategorySummary({
+    required this.categoryId,
+    required this.name,
+    required this.plannedAmount,
+    required this.spentAmount,
+    required this.remainingAmount,
+    required this.usagePercent,
+    required this.isOverBudget,
+    required this.isNearLimit,
+  });
+
+  final String categoryId;
+  final String name;
+  final double plannedAmount;
+  final double spentAmount;
+  final double remainingAmount;
+  final double usagePercent;
+  final bool isOverBudget;
+  final bool isNearLimit;
+}

--- a/lib/features/home/domain/entities/dashboard_source_models.dart
+++ b/lib/features/home/domain/entities/dashboard_source_models.dart
@@ -1,0 +1,51 @@
+class DashboardBudgetProfileData {
+  const DashboardBudgetProfileData({
+    required this.id,
+    required this.monthlyIncome,
+    required this.monthlyFixedExpenses,
+    required this.safetyBuffer,
+    required this.distributableAmount,
+    required this.currencyCode,
+    this.displayName,
+  });
+
+  final String id;
+  final double monthlyIncome;
+  final double monthlyFixedExpenses;
+  final double safetyBuffer;
+  final double distributableAmount;
+  final String currencyCode;
+  final String? displayName;
+}
+
+class DashboardCategoryData {
+  const DashboardCategoryData({
+    required this.id,
+    required this.name,
+    required this.allocationPercent,
+    required this.plannedAmount,
+    required this.sortOrder,
+    required this.isDefault,
+  });
+
+  final String id;
+  final String name;
+  final double allocationPercent;
+  final double plannedAmount;
+  final int sortOrder;
+  final bool isDefault;
+}
+
+class DashboardExpenseData {
+  const DashboardExpenseData({
+    required this.id,
+    required this.budgetCategoryId,
+    required this.amount,
+    required this.expenseDate,
+  });
+
+  final String id;
+  final String budgetCategoryId;
+  final double amount;
+  final DateTime expenseDate;
+}

--- a/lib/features/home/domain/entities/home_insight.dart
+++ b/lib/features/home/domain/entities/home_insight.dart
@@ -1,0 +1,18 @@
+enum HomeInsightTone {
+  neutral,
+  positive,
+  warning,
+  danger,
+}
+
+class HomeInsight {
+  const HomeInsight({
+    required this.title,
+    required this.message,
+    required this.tone,
+  });
+
+  final String title;
+  final String message;
+  final HomeInsightTone tone;
+}

--- a/lib/features/home/domain/entities/home_summary.dart
+++ b/lib/features/home/domain/entities/home_summary.dart
@@ -1,0 +1,32 @@
+import 'category_summary.dart';
+import 'home_insight.dart';
+
+class HomeSummary {
+  const HomeSummary({
+    required this.displayName,
+    required this.currencyCode,
+    required this.monthlyRemaining,
+    required this.safelySpendable,
+    required this.monthlyIncome,
+    required this.fixedExpenses,
+    required this.safetyBuffer,
+    required this.distributableAmount,
+    required this.totalSpentThisMonth,
+    required this.categorySummaries,
+    required this.highlightedCategory,
+    required this.insight,
+  });
+
+  final String displayName;
+  final String currencyCode;
+  final double monthlyRemaining;
+  final double safelySpendable;
+  final double monthlyIncome;
+  final double fixedExpenses;
+  final double safetyBuffer;
+  final double distributableAmount;
+  final double totalSpentThisMonth;
+  final List<CategorySummary> categorySummaries;
+  final CategorySummary? highlightedCategory;
+  final HomeInsight insight;
+}

--- a/lib/features/home/domain/services/home_summary_calculator.dart
+++ b/lib/features/home/domain/services/home_summary_calculator.dart
@@ -1,0 +1,154 @@
+import '../entities/category_summary.dart';
+import '../entities/dashboard_source_models.dart';
+import '../entities/home_insight.dart';
+import '../entities/home_summary.dart';
+
+class HomeSummaryCalculator {
+  const HomeSummaryCalculator();
+
+  HomeSummary calculate({
+    required DashboardBudgetProfileData profile,
+    required List<DashboardCategoryData> categories,
+    required List<DashboardExpenseData> expenses,
+  }) {
+    final spentByCategory = <String, double>{};
+
+    for (final expense in expenses) {
+      spentByCategory.update(
+        expense.budgetCategoryId,
+        (value) => value + expense.amount,
+        ifAbsent: () => expense.amount,
+      );
+    }
+
+    final categorySummaries = categories
+        .map(
+          (category) {
+            final spentAmount = spentByCategory[category.id] ?? 0;
+            final plannedAmount = category.plannedAmount;
+            final remainingAmount = plannedAmount - spentAmount;
+            final usagePercent = plannedAmount <= 0
+                ? (spentAmount > 0 ? 1.0 : 0.0)
+                : (spentAmount / plannedAmount).clamp(0.0, 2.0);
+
+            return CategorySummary(
+              categoryId: category.id,
+              name: category.name,
+              plannedAmount: plannedAmount,
+              spentAmount: spentAmount,
+              remainingAmount: remainingAmount,
+              usagePercent: usagePercent,
+              isOverBudget: remainingAmount < 0,
+              isNearLimit: remainingAmount >= 0 && usagePercent >= 0.85,
+            );
+          },
+        )
+        .toList()
+      ..sort((a, b) => a.name.compareTo(b.name));
+
+    final totalSpentThisMonth = expenses.fold<double>(
+      0,
+      (sum, expense) => sum + expense.amount,
+    );
+
+    final monthlyRemaining =
+        profile.monthlyIncome - profile.monthlyFixedExpenses - totalSpentThisMonth;
+
+    final safelySpendable = (monthlyRemaining - profile.safetyBuffer)
+        .clamp(0.0, double.infinity);
+
+    final highlightedCategory = _pickHighlightedCategory(categorySummaries);
+
+    return HomeSummary(
+      displayName: profile.displayName?.trim().isNotEmpty == true
+          ? profile.displayName!.trim()
+          : 'Patrik',
+      currencyCode: profile.currencyCode,
+      monthlyRemaining: monthlyRemaining,
+      safelySpendable: safelySpendable,
+      monthlyIncome: profile.monthlyIncome,
+      fixedExpenses: profile.monthlyFixedExpenses,
+      safetyBuffer: profile.safetyBuffer,
+      distributableAmount: profile.distributableAmount,
+      totalSpentThisMonth: totalSpentThisMonth,
+      categorySummaries: categorySummaries,
+      highlightedCategory: highlightedCategory,
+      insight: _buildInsight(
+        categorySummaries: categorySummaries,
+        expenses: expenses,
+        safelySpendable: safelySpendable,
+        monthlyRemaining: monthlyRemaining,
+      ),
+    );
+  }
+
+  CategorySummary? _pickHighlightedCategory(List<CategorySummary> categories) {
+    if (categories.isEmpty) {
+      return null;
+    }
+
+    final foodMatch = categories.where(
+      (category) => category.name.toLowerCase().contains('toit'),
+    );
+
+    if (foodMatch.isNotEmpty) {
+      return foodMatch.first;
+    }
+
+    final sorted = [...categories]
+      ..sort((a, b) => b.plannedAmount.compareTo(a.plannedAmount));
+
+    return sorted.first;
+  }
+
+  HomeInsight _buildInsight({
+    required List<CategorySummary> categorySummaries,
+    required List<DashboardExpenseData> expenses,
+    required double safelySpendable,
+    required double monthlyRemaining,
+  }) {
+    final overBudget = categorySummaries.where((item) => item.isOverBudget).toList();
+    if (overBudget.isNotEmpty) {
+      final first = overBudget.first;
+      return HomeInsight(
+        title: 'Tähelepanu',
+        message:
+            'Kategooria "${first.name}" on oma eelarve ületanud. Vaata järgmised kulud seal üle.',
+        tone: HomeInsightTone.danger,
+      );
+    }
+
+    final nearLimit = categorySummaries.where((item) => item.isNearLimit).toList();
+    if (nearLimit.isNotEmpty) {
+      final first = nearLimit.first;
+      return HomeInsight(
+        title: 'Jälgi tempot',
+        message:
+            'Kategooria "${first.name}" on piirile lähedal. Seal on jäänud vähe ruumi.',
+        tone: HomeInsightTone.warning,
+      );
+    }
+
+    if (expenses.isEmpty) {
+      return const HomeInsight(
+        title: 'Nutikas nõuanne',
+        message: 'Lisa esimene kulu ja avaleht hakkab sinu päris tempot paremini näitama.',
+        tone: HomeInsightTone.neutral,
+      );
+    }
+
+    if (monthlyRemaining <= 0 || safelySpendable <= 0) {
+      return const HomeInsight(
+        title: 'Hoia tagasi',
+        message: 'Selle kuu turvaline varu on otsas. Uued kulud tasub teha ettevaatlikult.',
+        tone: HomeInsightTone.warning,
+      );
+    }
+
+    return const HomeInsight(
+      title: 'Nutikas nõuanne',
+      message: 'Sinu kulutempo tundub hetkel stabiilne ja puhver on alles.',
+      tone: HomeInsightTone.positive,
+    );
+  }
+}

--- a/lib/features/home/presentation/home_screen.dart
+++ b/lib/features/home/presentation/home_screen.dart
@@ -1,16 +1,131 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
-class HomeScreen extends StatelessWidget {
+import 'providers/home_summary_provider.dart';
+import 'widgets/dashboard_currency.dart';
+import 'widgets/dashboard_header.dart';
+import 'widgets/home_category_highlight_card.dart';
+import 'widgets/home_empty_state.dart';
+import 'widgets/home_insight_card.dart';
+import 'widgets/home_primary_summary_card.dart';
+import 'widgets/home_stat_card.dart';
+
+class HomeScreen extends ConsumerWidget {
   const HomeScreen({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    return Center(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: const [
-          Text('Home screen'),
-        ],
+  Widget build(BuildContext context, WidgetRef ref) {
+    final summaryAsync = ref.watch(homeSummaryProvider);
+
+    return Scaffold(
+      body: SafeArea(
+        child: summaryAsync.when(
+          loading: () => const Center(child: CircularProgressIndicator()),
+          error: (e, _) => Center(child: Text('Viga: $e')),
+          data: (summaryState) {
+            if (!summaryState.isConfigured || summaryState.summary == null) {
+              return HomeEmptyState(onOpenSetup: () => context.go('/setup'));
+            }
+
+            final summary = summaryState.summary!;
+
+            return Column(
+              children: [
+                Expanded(
+                  child: RefreshIndicator(
+                    onRefresh: () =>
+                        ref.read(homeSummaryProvider.notifier).refresh(),
+                    child: ListView(
+                      padding: const EdgeInsets.fromLTRB(20, 16, 20, 16),
+                      children: [
+                        DashboardHeader(displayName: summary.displayName),
+                        const SizedBox(height: 24),
+                        Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              'Sellel kuu alles',
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .bodyMedium
+                                  ?.copyWith(
+                                    color: const Color(0xFF6B7B79),
+                                    fontWeight: FontWeight.w500,
+                                  ),
+                            ),
+                            const SizedBox(height: 4),
+                            Text(
+                              formatCurrency(summary.monthlyRemaining),
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .displaySmall
+                                  ?.copyWith(
+                                    fontWeight: FontWeight.w900,
+                                    color: const Color(0xFF021C36),
+                                  ),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 20),
+                        HomePrimarySummaryCard(summary: summary),
+                        const SizedBox(height: 12),
+                        Row(
+                          children: [
+                            Expanded(
+                              child: HomeStatCard(
+                                label: 'Püsikulud',
+                                value: summary.fixedExpenses,
+                              ),
+                            ),
+                            const SizedBox(width: 12),
+                            Expanded(
+                              child: HomeStatCard(
+                                label: 'Puhver',
+                                value: summary.safetyBuffer,
+                              ),
+                            ),
+                          ],
+                        ),
+                        if (summary.highlightedCategory != null) ...[
+                          const SizedBox(height: 12),
+                          HomeCategoryHighlightCard(
+                            category: summary.highlightedCategory!,
+                          ),
+                        ],
+                        const SizedBox(height: 12),
+                        HomeInsightCard(insight: summary.insight),
+                      ],
+                    ),
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(20, 8, 20, 16),
+                  child: SizedBox(
+                    width: double.infinity,
+                    child: FilledButton.icon(
+                      onPressed: () => context.go('/addexpense'),
+                      style: FilledButton.styleFrom(
+                        backgroundColor: const Color(0xFF006763),
+                        foregroundColor: Colors.white,
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 32,
+                          vertical: 26,
+                        ),
+                        shape: const StadiumBorder(),
+                      ),
+                      icon: const Icon(Icons.add),
+                      label: const Text(
+                        'Lisa uus kulu',
+                        style: TextStyle(fontWeight: FontWeight.w700),
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            );
+          },
+        ),
       ),
     );
   }

--- a/lib/features/home/presentation/providers/dashboard_dependencies.dart
+++ b/lib/features/home/presentation/providers/dashboard_dependencies.dart
@@ -1,0 +1,73 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../setup/data/datasources/setup_local_data_source.dart';
+import '../../../setup/data/repositories/setup_repository.dart';
+import '../../../setup/data/repositories/setup_repository_impl.dart';
+import '../../../setup/presentation/providers/setup_notifier.dart';
+import '../../domain/entities/dashboard_source_models.dart';
+
+abstract class DashboardDataGateway {
+  Future<DashboardBudgetProfileData?> getBudgetProfile();
+
+  Future<List<DashboardCategoryData>> getCategoriesForProfile(String profileId);
+
+  Future<List<DashboardExpenseData>> getExpensesForMonth({
+    required DateTime month,
+  });
+}
+
+class _SetupRepositoryGateway implements DashboardDataGateway {
+  const _SetupRepositoryGateway(this._repository);
+
+  final SetupRepository _repository;
+
+  @override
+  Future<DashboardBudgetProfileData?> getBudgetProfile() async {
+    final profile = await _repository.getBudgetProfile();
+    if (profile == null) return null;
+
+    return DashboardBudgetProfileData(
+      id: profile.id?.toString() ?? '0',
+      monthlyIncome: profile.monthlyIncome,
+      monthlyFixedExpenses: profile.monthlyFixedExpenses,
+      safetyBuffer: profile.safetyBuffer,
+      distributableAmount: profile.distributableAmount,
+      currencyCode: profile.currencyCode,
+    );
+  }
+
+  @override
+  Future<List<DashboardCategoryData>> getCategoriesForProfile(
+    String profileId,
+  ) async {
+    final categories = await _repository.getBudgetCategories();
+
+    return categories
+        .map(
+          (c) => DashboardCategoryData(
+            id: c.id?.toString() ?? c.name,
+            name: c.name,
+            allocationPercent: c.allocationPercent,
+            plannedAmount: c.plannedAmount,
+            sortOrder: c.sortOrder,
+            isDefault: c.isDefault,
+          ),
+        )
+        .toList();
+  }
+
+  @override
+  Future<List<DashboardExpenseData>> getExpensesForMonth({
+    required DateTime month,
+  }) async {
+    return [];
+  }
+}
+
+final dashboardDataGatewayProvider = Provider<DashboardDataGateway>((ref) {
+  final localDataSource = SetupLocalDataSource(
+    appDatabase: ref.watch(appDatabaseProvider),
+  );
+  final repository = SetupRepositoryImpl(localDataSource: localDataSource);
+  return _SetupRepositoryGateway(repository);
+});

--- a/lib/features/home/presentation/providers/home_summary_provider.dart
+++ b/lib/features/home/presentation/providers/home_summary_provider.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../domain/entities/home_summary.dart';
+import '../../domain/services/home_summary_calculator.dart';
+import 'dashboard_dependencies.dart';
+
+class HomeSummaryState {
+  const HomeSummaryState._({
+    required this.isConfigured,
+    required this.summary,
+  });
+
+  const HomeSummaryState.notConfigured()
+      : this._(
+          isConfigured: false,
+          summary: null,
+        );
+
+  const HomeSummaryState.configured(HomeSummary summary)
+      : this._(
+          isConfigured: true,
+          summary: summary,
+        );
+
+  final bool isConfigured;
+  final HomeSummary? summary;
+}
+
+final homeSummaryCalculatorProvider = Provider<HomeSummaryCalculator>(
+  (ref) => const HomeSummaryCalculator(),
+);
+
+final homeSummaryProvider =
+    AsyncNotifierProvider<HomeSummaryNotifier, HomeSummaryState>(
+  HomeSummaryNotifier.new,
+);
+
+class HomeSummaryNotifier extends AsyncNotifier<HomeSummaryState> {
+  @override
+  Future<HomeSummaryState> build() async {
+    final gateway = ref.read(dashboardDataGatewayProvider);
+    final calculator = ref.read(homeSummaryCalculatorProvider);
+
+    final profile = await gateway.getBudgetProfile();
+    if (profile == null) {
+      return const HomeSummaryState.notConfigured();
+    }
+
+    final categories = await gateway.getCategoriesForProfile(profile.id);
+    final expenses = await gateway.getExpensesForMonth(month: DateTime.now());
+
+    final summary = calculator.calculate(
+      profile: profile,
+      categories: categories,
+      expenses: expenses,
+    );
+
+    return HomeSummaryState.configured(summary);
+  }
+
+  Future<void> refresh() async {
+    state = const AsyncLoading();
+    state = await AsyncValue.guard(build);
+  }
+}

--- a/lib/features/home/presentation/widgets/dashboard_currency.dart
+++ b/lib/features/home/presentation/widgets/dashboard_currency.dart
@@ -1,0 +1,9 @@
+import 'package:intl/intl.dart';
+
+String formatCurrency(
+  double value, {
+  String currencySymbol = '€',
+}) {
+  final format = NumberFormat('#,##0.00', 'et_EE');
+  return '${format.format(value)} $currencySymbol';
+}

--- a/lib/features/home/presentation/widgets/dashboard_header.dart
+++ b/lib/features/home/presentation/widgets/dashboard_header.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+
+class DashboardHeader extends StatelessWidget {
+  const DashboardHeader({
+    super.key,
+    required this.displayName,
+  });
+
+  final String displayName;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        const CircleAvatar(
+          radius: 22,
+          backgroundColor: Color(0xFFBFE7E3),
+          child: Text(
+            'K',
+            style: TextStyle(
+              color: Color(0xFF006763),
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Text(
+            'Tere, $displayName!',
+            style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.w800,
+                ),
+          ),
+        ),
+        Text(
+          'Bigbank',
+          style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                color: const Color(0xFF006763),
+                fontWeight: FontWeight.w800,
+              ),
+        ),
+        const SizedBox(width: 8),
+        IconButton(
+          onPressed: () {},
+          icon: const Icon(
+            Icons.notifications_none_rounded,
+            color: Color(0xFF006763),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/home/presentation/widgets/home_category_highlight_card.dart
+++ b/lib/features/home/presentation/widgets/home_category_highlight_card.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+
+import '../../domain/entities/category_summary.dart';
+import 'dashboard_currency.dart';
+
+class HomeCategoryHighlightCard extends StatelessWidget {
+  const HomeCategoryHighlightCard({
+    super.key,
+    required this.category,
+  });
+
+  final CategorySummary category;
+
+  @override
+  Widget build(BuildContext context) {
+    final progress = category.plannedAmount <= 0
+        ? 0.0
+        : (category.spentAmount / category.plannedAmount).clamp(0.0, 1.0);
+
+    final progressColor = category.isOverBudget
+        ? const Color(0xFFBA1A1A)
+        : category.isNearLimit
+            ? const Color(0xFFB25D36)
+            : const Color(0xFF006763);
+
+    return Container(
+      padding: const EdgeInsets.all(18),
+      decoration: BoxDecoration(
+        color: const Color(0xFFF3F7FF),
+        borderRadius: BorderRadius.circular(24),
+      ),
+      child: Row(
+        children: [
+          Container(
+            width: 48,
+            height: 48,
+            decoration: const BoxDecoration(
+              color: Colors.white,
+              shape: BoxShape.circle,
+            ),
+            child: const Icon(
+              Icons.restaurant_rounded,
+              color: Color(0xFF006763),
+            ),
+          ),
+          const SizedBox(width: 14),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  category.name,
+                  style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                        fontWeight: FontWeight.w800,
+                      ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  formatCurrency(category.plannedAmount),
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: const Color(0xFF6B7B79),
+                      ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 12),
+          SizedBox(
+            width: 110,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                Text(
+                  'jääk: ${formatCurrency(category.remainingAmount)}',
+                  style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                        fontWeight: FontWeight.w800,
+                      ),
+                  textAlign: TextAlign.right,
+                ),
+                const SizedBox(height: 8),
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(999),
+                  child: LinearProgressIndicator(
+                    value: progress,
+                    minHeight: 6,
+                    backgroundColor: const Color(0xFFE3EAE9),
+                    valueColor: AlwaysStoppedAnimation(progressColor),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/home/presentation/widgets/home_empty_state.dart
+++ b/lib/features/home/presentation/widgets/home_empty_state.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+
+class HomeEmptyState extends StatelessWidget {
+  const HomeEmptyState({
+    super.key,
+    required this.onOpenSetup,
+  });
+
+  final VoidCallback onOpenSetup;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Container(
+          padding: const EdgeInsets.all(24),
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(28),
+            border: Border.all(color: const Color(0xFFDCE4E3)),
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Icon(
+                Icons.savings_outlined,
+                size: 42,
+                color: Color(0xFF006763),
+              ),
+              const SizedBox(height: 16),
+              Text(
+                'Avaleht vajab setupi',
+                style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                      fontWeight: FontWeight.w800,
+                    ),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 8),
+              Text(
+                'Sisesta esmalt sissetulek, püsikulud, puhver ja kategooriad. Siis saab avaleht sulle päris summary arvutada.',
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      color: const Color(0xFF5B6A69),
+                    ),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 20),
+              FilledButton(
+                onPressed: onOpenSetup,
+                style: FilledButton.styleFrom(
+                  backgroundColor: const Color(0xFF006763),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 20,
+                    vertical: 14,
+                  ),
+                ),
+                child: const Text('Ava setup'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/home/presentation/widgets/home_insight_card.dart
+++ b/lib/features/home/presentation/widgets/home_insight_card.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/material.dart';
+
+import '../../domain/entities/home_insight.dart';
+
+class HomeInsightCard extends StatelessWidget {
+  const HomeInsightCard({
+    super.key,
+    required this.insight,
+  });
+
+  final HomeInsight insight;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = _resolveColors(insight.tone);
+
+    return Container(
+      padding: const EdgeInsets.all(18),
+      decoration: BoxDecoration(
+        color: colors.background,
+        borderRadius: BorderRadius.circular(24),
+        border: Border.all(color: colors.border),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            padding: const EdgeInsets.all(10),
+            decoration: BoxDecoration(
+              color: colors.iconBackground,
+              borderRadius: BorderRadius.circular(16),
+            ),
+            child: Icon(colors.icon, color: colors.iconColor),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  insight.title,
+                  style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                        color: colors.titleColor,
+                        fontWeight: FontWeight.w800,
+                      ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  insight.message,
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        color: colors.messageColor,
+                      ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _InsightColors {
+  const _InsightColors({
+    required this.background,
+    required this.border,
+    required this.iconBackground,
+    required this.iconColor,
+    required this.icon,
+    required this.titleColor,
+    required this.messageColor,
+  });
+
+  final Color background;
+  final Color border;
+  final Color iconBackground;
+  final Color iconColor;
+  final IconData icon;
+  final Color titleColor;
+  final Color messageColor;
+}
+
+_InsightColors _resolveColors(HomeInsightTone tone) {
+  switch (tone) {
+    case HomeInsightTone.positive:
+      return const _InsightColors(
+        background: Color(0xFFEAF8F5),
+        border: Color(0xFFCBE9E1),
+        iconBackground: Color(0xFFBFE7E3),
+        iconColor: Color(0xFF006763),
+        icon: Icons.lightbulb_outline,
+        titleColor: Color(0xFF006763),
+        messageColor: Color(0xFF3F5A57),
+      );
+    case HomeInsightTone.warning:
+      return const _InsightColors(
+        background: Color(0xFFFFF5E8),
+        border: Color(0xFFFFE1B0),
+        iconBackground: Color(0xFFFFE9C7),
+        iconColor: Color(0xFF9A5C00),
+        icon: Icons.warning_amber_rounded,
+        titleColor: Color(0xFF9A5C00),
+        messageColor: Color(0xFF6F5937),
+      );
+    case HomeInsightTone.danger:
+      return const _InsightColors(
+        background: Color(0xFFFFECE9),
+        border: Color(0xFFF4C7C2),
+        iconBackground: Color(0xFFFFDAD6),
+        iconColor: Color(0xFFBA1A1A),
+        icon: Icons.error_outline,
+        titleColor: Color(0xFFBA1A1A),
+        messageColor: Color(0xFF6D4B48),
+      );
+    case HomeInsightTone.neutral:
+      return const _InsightColors(
+        background: Color(0xFFF1F6F6),
+        border: Color(0xFFD9E4E3),
+        iconBackground: Color(0xFFE3ECEB),
+        iconColor: Color(0xFF436C68),
+        icon: Icons.info_outline,
+        titleColor: Color(0xFF436C68),
+        messageColor: Color(0xFF4E6160),
+      );
+  }
+}

--- a/lib/features/home/presentation/widgets/home_primary_summary_card.dart
+++ b/lib/features/home/presentation/widgets/home_primary_summary_card.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+
+import '../../domain/entities/home_summary.dart';
+import 'dashboard_currency.dart';
+
+class HomePrimarySummaryCard extends StatelessWidget {
+  const HomePrimarySummaryCard({
+    super.key,
+    required this.summary,
+  });
+
+  final HomeSummary summary;
+
+  @override
+  Widget build(BuildContext context) {
+    final distributable = summary.distributableAmount <= 0
+        ? 1.0
+        : summary.distributableAmount;
+    final progress = (summary.safelySpendable / distributable).clamp(0.0, 1.0);
+
+    return Container(
+      padding: const EdgeInsets.all(22),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(28),
+        border: Border.all(color: const Color(0xFFE2EAE9)),
+        boxShadow: const [
+          BoxShadow(
+            color: Color(0x0A000000),
+            blurRadius: 20,
+            offset: Offset(0, 8),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Turvaliselt kulutatav'.toUpperCase(),
+            style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                  color: const Color(0xFF6B7B79),
+                  fontWeight: FontWeight.w800,
+                  letterSpacing: 1.2,
+                ),
+          ),
+          const SizedBox(height: 10),
+          Text(
+            formatCurrency(summary.safelySpendable),
+            style: Theme.of(context).textTheme.headlineMedium?.copyWith(
+                  color: const Color(0xFF006763),
+                  fontWeight: FontWeight.w800,
+                ),
+          ),
+          const SizedBox(height: 20),
+          ClipRRect(
+            borderRadius: BorderRadius.circular(999),
+            child: LinearProgressIndicator(
+              value: progress,
+              minHeight: 7,
+              backgroundColor: const Color(0xFFE7EFEE),
+              valueColor: const AlwaysStoppedAnimation(Color(0xFF006763)),
+            ),
+          ),
+          const SizedBox(height: 8),
+          Align(
+            alignment: Alignment.centerRight,
+            child: Text(
+              '${(progress * 100).round()}%',
+              style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                    color: const Color(0xFF6B7B79),
+                    fontWeight: FontWeight.w700,
+                  ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/home/presentation/widgets/home_stat_card.dart
+++ b/lib/features/home/presentation/widgets/home_stat_card.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+
+import 'dashboard_currency.dart';
+
+class HomeStatCard extends StatelessWidget {
+  const HomeStatCard({
+    super.key,
+    required this.label,
+    required this.value,
+  });
+
+  final String label;
+  final double value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(18),
+      decoration: BoxDecoration(
+        color: const Color(0xFFF1F5FF),
+        borderRadius: BorderRadius.circular(24),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            label,
+            style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                  color: const Color(0xFF6B7B79),
+                ),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            formatCurrency(value),
+            style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.w800,
+                ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/setup/presentation/setup_screen.dart
+++ b/lib/features/setup/presentation/setup_screen.dart
@@ -1,11 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../../app/theme/app_colors.dart';
 import '../../../app/theme/app_radius.dart';
 import '../../../app/theme/app_spacing.dart';
 import '../../../app/theme/app_text_styles.dart';
 import 'providers/setup_notifier.dart';
+import 'providers/setup_state.dart';
 
 class SetupScreen extends StatelessWidget {
   const SetupScreen({super.key});
@@ -121,6 +123,10 @@ class _SetupFormCardState extends ConsumerState<_SetupFormCard> {
     incomeController.text = state.monthlyIncomeInput;
     fixedExpensesController.text = state.monthlyFixedExpensesInput;
     bufferController.text = state.safetyBufferInput;
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      ref.read(setupNotifierProvider.notifier).loadSavedSetupIfExists();
+    });
   }
 
   @override
@@ -136,6 +142,12 @@ class _SetupFormCardState extends ConsumerState<_SetupFormCard> {
   Widget build(BuildContext context) {
     final state = ref.watch(setupNotifierProvider);
     final notifier = ref.read(setupNotifierProvider.notifier);
+
+    ref.listen<SetupState>(setupNotifierProvider, (_, next) {
+      if (next.hasCompletedSetup && mounted) {
+        context.go('/');
+      }
+    });
 
     final distributableAmount = notifier.distributableAmount;
     final totalAllocatedPercent = notifier.totalAllocatedPercent;
@@ -449,7 +461,10 @@ class _SetupFormCardState extends ConsumerState<_SetupFormCard> {
             onPressed: state.isSaving
                 ? null
                 : () async {
-                    await notifier.saveSetup();
+                    final success = await notifier.saveSetup();
+                    if (success && context.mounted) {
+                      context.go('/');
+                    }
                   },
               style: FilledButton.styleFrom(
                 backgroundColor: const Color.fromARGB(255, 11, 99, 93),


### PR DESCRIPTION
Closes #7 

Added the summary calculation logic outside of widgets, set up the provider/notifier flow, and built the core UI sections like the main summary card, stats, insight block, and empty/not configured states.

The screen now follows the planned architecture better and is ready to be connected fully with real saved setup and expense data if anything is still missing.