### PR TITLE
add grocery budget tracking and rebalancing flow

### DIFF
--- a/lib/features/expenses/data/datasources/expense_local_data_source.dart
+++ b/lib/features/expenses/data/datasources/expense_local_data_source.dart
@@ -26,4 +26,22 @@ class ExpenseLocalDataSource {
 
     return result.map(Expense.fromMap).toList();
   }
+
+  Future<List<Expense>> getExpensesForCategoryInMonth(
+    int categoryId,
+    DateTime month,
+  ) async {
+    final db = await appDatabase.database;
+    final start = DateTime(month.year, month.month, 1).toIso8601String();
+    final end = DateTime(month.year, month.month + 1, 1).toIso8601String();
+
+    final result = await db.query(
+      'expenses',
+      where: 'budget_category_id = ? AND expense_date >= ? AND expense_date < ?',
+      whereArgs: [categoryId, start, end],
+      orderBy: 'expense_date DESC',
+    );
+
+    return result.map(Expense.fromMap).toList();
+  }
 }

--- a/lib/features/expenses/data/repositories/expense_repository.dart
+++ b/lib/features/expenses/data/repositories/expense_repository.dart
@@ -3,4 +3,8 @@ import '../../domain/models/expense.dart';
 abstract class ExpenseRepository {
   Future<int> saveExpense(Expense expense);
   Future<List<Expense>> getExpensesForMonth(DateTime month);
+  Future<List<Expense>> getExpensesForCategoryInMonth(
+    int categoryId,
+    DateTime month,
+  );
 }

--- a/lib/features/expenses/data/repositories/expense_repository_impl.dart
+++ b/lib/features/expenses/data/repositories/expense_repository_impl.dart
@@ -16,4 +16,12 @@ class ExpenseRepositoryImpl implements ExpenseRepository {
   Future<List<Expense>> getExpensesForMonth(DateTime month) {
     return localDataSource.getExpensesForMonth(month);
   }
+
+  @override
+  Future<List<Expense>> getExpensesForCategoryInMonth(
+    int categoryId,
+    DateTime month,
+  ) {
+    return localDataSource.getExpensesForCategoryInMonth(categoryId, month);
+  }
 }

--- a/lib/features/grocery/domain/models/category_budget_overview.dart
+++ b/lib/features/grocery/domain/models/category_budget_overview.dart
@@ -1,0 +1,43 @@
+import 'category_budget_status.dart';
+
+class CategoryBudgetOverview {
+  const CategoryBudgetOverview({
+    required this.categoryId,
+    required this.categoryName,
+    required this.plannedAmount,
+    required this.spentAmount,
+    required this.remainingAmount,
+    required this.totalDaysInMonth,
+    required this.elapsedDays,
+    required this.remainingDays,
+    required this.status,
+    required this.usagePercent,
+    this.suggestedDailyAmount,
+  });
+
+  final int categoryId;
+  final String categoryName;
+
+  final double plannedAmount;
+
+  final double spentAmount;
+
+  final double remainingAmount;
+
+  final int totalDaysInMonth;
+
+
+  final int elapsedDays;
+
+  final int remainingDays;
+
+  final CategoryBudgetStatus status;
+
+  final double usagePercent;
+
+  final double? suggestedDailyAmount;
+
+  double get overspentAmount => remainingAmount < 0 ? remainingAmount.abs() : 0;
+
+  bool get isOverBudget => status == CategoryBudgetStatus.overBudget;
+}

--- a/lib/features/grocery/domain/models/category_budget_status.dart
+++ b/lib/features/grocery/domain/models/category_budget_status.dart
@@ -1,0 +1,11 @@
+enum CategoryBudgetStatus {
+
+  underBudget,
+
+  onTrack,
+
+  /// not yet exceeded but usage is >= 85% risk.
+  nearLimit,
+
+  overBudget,
+}

--- a/lib/features/grocery/domain/services/budget_rebalancing_service.dart
+++ b/lib/features/grocery/domain/services/budget_rebalancing_service.dart
@@ -1,0 +1,94 @@
+import '../models/category_budget_overview.dart';
+import '../models/category_budget_status.dart';
+
+class BudgetRebalancingService {
+  const BudgetRebalancingService();
+
+  CategoryBudgetOverview calculate({
+    required int categoryId,
+    required String categoryName,
+    required double plannedAmount,
+    required double spentAmount,
+    required DateTime now,
+  }) {
+    final totalDays = _daysInMonth(now.year, now.month);
+
+    final elapsedDays = now.day;
+    final remainingDays = totalDays - elapsedDays;
+
+    final remainingAmount = _round(plannedAmount - spentAmount);
+
+    final usagePercent = plannedAmount <= 0
+        ? (spentAmount > 0 ? 2.0 : 0.0)
+        : (spentAmount / plannedAmount).clamp(0.0, 2.0);
+
+    final status = _determineStatus(
+      plannedAmount: plannedAmount,
+      spentAmount: spentAmount,
+      remainingAmount: remainingAmount,
+      usagePercent: usagePercent,
+      elapsedDays: elapsedDays,
+      totalDays: totalDays,
+    );
+
+    final suggestedDailyAmount = _suggestDaily(
+      remainingAmount: remainingAmount,
+      remainingDays: remainingDays,
+      status: status,
+    );
+
+    return CategoryBudgetOverview(
+      categoryId: categoryId,
+      categoryName: categoryName,
+      plannedAmount: plannedAmount,
+      spentAmount: _round(spentAmount),
+      remainingAmount: remainingAmount,
+      totalDaysInMonth: totalDays,
+      elapsedDays: elapsedDays,
+      remainingDays: remainingDays,
+      status: status,
+      usagePercent: usagePercent,
+      suggestedDailyAmount: suggestedDailyAmount,
+    );
+  }
+
+  CategoryBudgetStatus _determineStatus({
+    required double plannedAmount,
+    required double spentAmount,
+    required double remainingAmount,
+    required double usagePercent,
+    required int elapsedDays,
+    required int totalDays,
+  }) {
+    if (remainingAmount < 0) return CategoryBudgetStatus.overBudget;
+    if (usagePercent >= 0.85) return CategoryBudgetStatus.nearLimit;
+
+    if (plannedAmount > 0 && totalDays > 0 && elapsedDays > 0) {
+      final expectedByNow = plannedAmount * (elapsedDays / totalDays);
+      if (spentAmount < expectedByNow * 0.8) {
+        return CategoryBudgetStatus.underBudget;
+      }
+    }
+
+    return CategoryBudgetStatus.onTrack;
+  }
+
+  double? _suggestDaily({
+    required double remainingAmount,
+    required int remainingDays,
+    required CategoryBudgetStatus status,
+  }) {
+    if (status == CategoryBudgetStatus.overBudget) return null;
+    if (remainingDays <= 0) return null;
+    return _round(remainingAmount / remainingDays);
+  }
+
+  static int _daysInMonth(int year, int month) {
+
+    return DateTime(year, month + 1, 0).day;
+  }
+
+  static double _round(double value) {
+    return (value * 100).round() / 100;
+  }
+}

--- a/lib/features/grocery/presentation/grocery_overview_screen.dart
+++ b/lib/features/grocery/presentation/grocery_overview_screen.dart
@@ -1,27 +1,544 @@
 import 'package:flutter/material.dart';
-import 'package:go_router/go_router.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-class GroceryOverviewScreen extends StatelessWidget {
+import '../../../app/theme/app_colors.dart';
+import '../../../app/theme/app_spacing.dart';
+import '../domain/models/category_budget_overview.dart';
+import '../domain/models/category_budget_status.dart';
+import 'providers/grocery_overview_provider.dart';
+
+class GroceryOverviewScreen extends ConsumerWidget {
   const GroceryOverviewScreen({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final overviewAsync = ref.watch(categoryBudgetOverviewProvider);
+
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('groceryscreen'),
-      )
-      ,
-      body: Center(
-        child: Column(
-          children: [
-            const Text('lowk'),
-            ElevatedButton(
-              onPressed: () => context.go('/'),
-              child: const Text('back to home'),
+      backgroundColor: AppColors.background,
+      body: SafeArea(
+        child: overviewAsync.when(
+          loading: () => const Center(child: CircularProgressIndicator()),
+          error: (e, _) => _ErrorState(message: e.toString()),
+          data: (state) {
+            if (!state.isConfigured) {
+              return const _NotConfiguredState();
+            }
+            if (!state.hasCategories) {
+              return const _NoCategoriesState();
+            }
+            return _OverviewBody(state: state);
+          },
+        ),
+      ),
+    );
+  }
+}
+
+// ── Main content ─────────────────────────────────────────────────────────────
+
+class _OverviewBody extends ConsumerWidget {
+  const _OverviewBody({required this.state});
+
+  final CategoryBudgetOverviewState state;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final now = DateTime.now();
+    final monthLabel = '${_estonianMonth(now.month)} ${now.year}';
+
+    return RefreshIndicator(
+      onRefresh: () =>
+          ref.read(categoryBudgetOverviewProvider.notifier).refresh(),
+      child: ListView(
+        padding: const EdgeInsets.fromLTRB(20, 16, 20, 32),
+        children: [
+          _ScreenHeader(monthLabel: monthLabel),
+          const SizedBox(height: 8),
+          _MonthSummaryRow(overviews: state.overviews),
+          const SizedBox(height: 20),
+          ...state.overviews.map(
+            (overview) => Padding(
+              padding: const EdgeInsets.only(bottom: 12),
+              child: _CategoryCard(overview: overview),
             ),
-            ElevatedButton(
-              onPressed: () => context.go('/settings'),
-              child: const Text('settings?'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ── Screen header ─────────────────────────────────────────────────────────────
+
+class _ScreenHeader extends StatelessWidget {
+  const _ScreenHeader({required this.monthLabel});
+
+  final String monthLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Kategooriad',
+          style: Theme.of(context).textTheme.headlineMedium?.copyWith(
+                fontWeight: FontWeight.w800,
+                color: const Color(0xFF021C36),
+              ),
+        ),
+        const SizedBox(height: 2),
+        Text(
+          monthLabel,
+          style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                color: AppColors.textSecondary,
+              ),
+        ),
+      ],
+    );
+  }
+}
+
+// ── Month summary row (totals across all categories) ─────────────────────────
+
+class _MonthSummaryRow extends StatelessWidget {
+  const _MonthSummaryRow({required this.overviews});
+
+  final List<CategoryBudgetOverview> overviews;
+
+  @override
+  Widget build(BuildContext context) {
+    final totalPlanned =
+        overviews.fold<double>(0, (s, o) => s + o.plannedAmount);
+    final totalSpent = overviews.fold<double>(0, (s, o) => s + o.spentAmount);
+    final totalRemaining = totalPlanned - totalSpent;
+    final overBudgetCount = overviews.where((o) => o.isOverBudget).length;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: AppColors.border),
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: _SummaryItem(
+              label: 'Kokku plaan',
+              value: _fmt(totalPlanned),
+              color: AppColors.textPrimary,
+            ),
+          ),
+          _Divider(),
+          Expanded(
+            child: _SummaryItem(
+              label: 'Kulutatud',
+              value: _fmt(totalSpent),
+              color: AppColors.textPrimary,
+            ),
+          ),
+          _Divider(),
+          Expanded(
+            child: _SummaryItem(
+              label: 'Alles',
+              value: _fmt(totalRemaining),
+              color: totalRemaining < 0
+                  ? AppColors.error
+                  : AppColors.success,
+            ),
+          ),
+          if (overBudgetCount > 0) ...[
+            _Divider(),
+            Expanded(
+              child: _SummaryItem(
+                label: 'Üle eelarve',
+                value: '$overBudgetCount',
+                color: AppColors.error,
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _SummaryItem extends StatelessWidget {
+  const _SummaryItem({
+    required this.label,
+    required this.value,
+    required this.color,
+  });
+
+  final String label;
+  final String value;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Text(
+          label,
+          style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: AppColors.textSecondary,
+                fontSize: 11,
+              ),
+          textAlign: TextAlign.center,
+        ),
+        const SizedBox(height: 4),
+        Text(
+          value,
+          style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                fontWeight: FontWeight.w800,
+                color: color,
+              ),
+          textAlign: TextAlign.center,
+        ),
+      ],
+    );
+  }
+}
+
+class _Divider extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 1,
+      height: 32,
+      margin: const EdgeInsets.symmetric(horizontal: 4),
+      color: AppColors.border,
+    );
+  }
+}
+
+// ── Category card ─────────────────────────────────────────────────────────────
+
+class _CategoryCard extends StatelessWidget {
+  const _CategoryCard({required this.overview});
+
+  final CategoryBudgetOverview overview;
+
+  @override
+  Widget build(BuildContext context) {
+    final statusColors = _StatusColors.from(overview.status);
+    final progress = overview.usagePercent.clamp(0.0, 1.0);
+
+    return Container(
+      padding: const EdgeInsets.all(18),
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: AppColors.border),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // ── Header row ──────────────────────────────────────────────────
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                overview.categoryName,
+                style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.w800,
+                      color: AppColors.textPrimary,
+                    ),
+              ),
+              _StatusBadge(status: overview.status, colors: statusColors),
+            ],
+          ),
+          const SizedBox(height: 14),
+
+          // ── Amounts row ──────────────────────────────────────────────────
+          Row(
+            children: [
+              Expanded(
+                child: _AmountItem(
+                  label: 'Planeeritud',
+                  value: _fmt(overview.plannedAmount),
+                  color: AppColors.textSecondary,
+                ),
+              ),
+              Expanded(
+                child: _AmountItem(
+                  label: 'Kulutatud',
+                  value: _fmt(overview.spentAmount),
+                  color: overview.isOverBudget
+                      ? AppColors.error
+                      : AppColors.textPrimary,
+                ),
+              ),
+              Expanded(
+                child: _AmountItem(
+                  label: 'Alles',
+                  value: _fmtSigned(overview.remainingAmount),
+                  color: overview.isOverBudget
+                      ? AppColors.error
+                      : overview.status == CategoryBudgetStatus.nearLimit
+                          ? AppColors.warning
+                          : AppColors.success,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 14),
+
+          // ── Progress bar ─────────────────────────────────────────────────
+          ClipRRect(
+            borderRadius: BorderRadius.circular(4),
+            child: LinearProgressIndicator(
+              value: progress,
+              minHeight: 6,
+              backgroundColor: statusColors.accent.withValues(alpha: 0.12),
+              valueColor: AlwaysStoppedAnimation<Color>(statusColors.accent),
+            ),
+          ),
+
+          // ── Daily suggestion ─────────────────────────────────────────────
+          if (overview.suggestedDailyAmount != null &&
+              overview.remainingDays > 0) ...[
+            const SizedBox(height: 12),
+            _DailySuggestionLine(overview: overview),
+          ],
+
+          // ── Overspent note ───────────────────────────────────────────────
+          if (overview.isOverBudget) ...[
+            const SizedBox(height: 12),
+            _OverspentLine(amount: overview.overspentAmount),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _AmountItem extends StatelessWidget {
+  const _AmountItem({
+    required this.label,
+    required this.value,
+    required this.color,
+  });
+
+  final String label;
+  final String value;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          label,
+          style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: AppColors.textMuted,
+                fontSize: 11,
+              ),
+        ),
+        const SizedBox(height: 3),
+        Text(
+          value,
+          style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                fontWeight: FontWeight.w700,
+                color: color,
+              ),
+        ),
+      ],
+    );
+  }
+}
+
+class _DailySuggestionLine extends StatelessWidget {
+  const _DailySuggestionLine({required this.overview});
+
+  final CategoryBudgetOverview overview;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        const Icon(
+          Icons.calendar_today_outlined,
+          size: 13,
+          color: Color(0xFF006763),
+        ),
+        const SizedBox(width: 6),
+        Expanded(
+          child: Text(
+            'Ülejäänud ${overview.remainingDays} päevaks ~${_fmt(overview.suggestedDailyAmount!)} päevas',
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: const Color(0xFF3F5A57),
+                  fontWeight: FontWeight.w600,
+                ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _OverspentLine extends StatelessWidget {
+  const _OverspentLine({required this.amount});
+
+  final double amount;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        const Icon(Icons.error_outline, size: 13, color: Color(0xFFBA1A1A)),
+        const SizedBox(width: 6),
+        Expanded(
+          child: Text(
+            '${_fmt(amount)} üle planeeritud summa',
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: const Color(0xFFBA1A1A),
+                  fontWeight: FontWeight.w600,
+                ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// ── Status badge ──────────────────────────────────────────────────────────────
+
+class _StatusBadge extends StatelessWidget {
+  const _StatusBadge({required this.status, required this.colors});
+
+  final CategoryBudgetStatus status;
+  final _StatusColors colors;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+      decoration: BoxDecoration(
+        color: colors.iconBackground,
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(colors.icon, size: 12, color: colors.accent),
+          const SizedBox(width: 4),
+          Text(
+            _label(status),
+            style: TextStyle(
+              fontSize: 11,
+              fontWeight: FontWeight.w700,
+              color: colors.accent,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _label(CategoryBudgetStatus s) {
+    switch (s) {
+      case CategoryBudgetStatus.underBudget:
+        return 'Ees plaanis';
+      case CategoryBudgetStatus.onTrack:
+        return 'Graafikus';
+      case CategoryBudgetStatus.nearLimit:
+        return 'Läheneb piirile';
+      case CategoryBudgetStatus.overBudget:
+        return 'Üle eelarve';
+    }
+  }
+}
+
+// ── Empty / error states ──────────────────────────────────────────────────────
+
+class _NotConfiguredState extends StatelessWidget {
+  const _NotConfiguredState();
+
+  @override
+  Widget build(BuildContext context) {
+    return _EmptyLayout(
+      icon: Icons.tune_outlined,
+      title: 'Seadistus puudub',
+      message: 'Eelarve ülevaate nägemiseks lõpeta esmalt esialgne seadistamine.',
+    );
+  }
+}
+
+class _NoCategoriesState extends StatelessWidget {
+  const _NoCategoriesState();
+
+  @override
+  Widget build(BuildContext context) {
+    return _EmptyLayout(
+      icon: Icons.category_outlined,
+      title: 'Kategooriaid pole',
+      message: 'Lisa seadistuses kulukategooriad, et siin ülevaadet näha.',
+    );
+  }
+}
+
+class _ErrorState extends StatelessWidget {
+  const _ErrorState({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return _EmptyLayout(
+      icon: Icons.error_outline,
+      title: 'Midagi läks valesti',
+      message: message,
+    );
+  }
+}
+
+class _EmptyLayout extends StatelessWidget {
+  const _EmptyLayout({
+    required this.icon,
+    required this.title,
+    required this.message,
+  });
+
+  final IconData icon;
+  final String title;
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 40),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              padding: const EdgeInsets.all(20),
+              decoration: BoxDecoration(
+                color: AppColors.inputFill,
+                shape: BoxShape.circle,
+              ),
+              child: Icon(icon, size: 36, color: AppColors.textSecondary),
+            ),
+            const SizedBox(height: AppSpacing.lg),
+            Text(
+              title,
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.w700,
+                    color: AppColors.textPrimary,
+                  ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            Text(
+              message,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: AppColors.textSecondary,
+                  ),
+              textAlign: TextAlign.center,
             ),
           ],
         ),
@@ -29,3 +546,58 @@ class GroceryOverviewScreen extends StatelessWidget {
     );
   }
 }
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Formats a non-negative amount as "X,XX €".
+String _fmt(double amount) =>
+    '${amount.abs().toStringAsFixed(2).replaceAll('.', ',')} €';
+
+/// Formats a possibly-negative amount, prefixing "−" when negative.
+String _fmtSigned(double amount) {
+  final abs = amount.abs().toStringAsFixed(2).replaceAll('.', ',');
+  return amount < 0 ? '−$abs €' : '$abs €';
+}
+
+class _StatusColors {
+  const _StatusColors({
+    required this.accent,
+    required this.iconBackground,
+    required this.icon,
+  });
+
+  factory _StatusColors.from(CategoryBudgetStatus status) {
+    switch (status) {
+      case CategoryBudgetStatus.underBudget:
+      case CategoryBudgetStatus.onTrack:
+        return const _StatusColors(
+          accent: Color(0xFF006763),
+          iconBackground: Color(0xFFBFE7E3),
+          icon: Icons.check_circle_outline,
+        );
+      case CategoryBudgetStatus.nearLimit:
+        return const _StatusColors(
+          accent: Color(0xFF9A5C00),
+          iconBackground: Color(0xFFFFE9C7),
+          icon: Icons.warning_amber_rounded,
+        );
+      case CategoryBudgetStatus.overBudget:
+        return const _StatusColors(
+          accent: Color(0xFFBA1A1A),
+          iconBackground: Color(0xFFFFDAD6),
+          icon: Icons.error_outline,
+        );
+    }
+  }
+
+  final Color accent;
+  final Color iconBackground;
+  final IconData icon;
+}
+
+const _estonianMonths = [
+  'jaanuar', 'veebruar', 'märts', 'aprill', 'mai', 'juuni',
+  'juuli', 'august', 'september', 'oktoober', 'november', 'detsember',
+];
+
+String _estonianMonth(int month) => _estonianMonths[month - 1];

--- a/lib/features/grocery/presentation/providers/grocery_overview_provider.dart
+++ b/lib/features/grocery/presentation/providers/grocery_overview_provider.dart
@@ -1,0 +1,99 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../expenses/presentation/providers/add_expense_notifier.dart';
+import '../../../setup/data/datasources/setup_local_data_source.dart';
+import '../../../setup/presentation/providers/setup_notifier.dart';
+import '../../domain/models/category_budget_overview.dart';
+import '../../domain/services/budget_rebalancing_service.dart';
+
+// ── State ────────────────────────────────────────────────────────────────────
+
+class CategoryBudgetOverviewState {
+  const CategoryBudgetOverviewState._({
+    required this.isConfigured,
+    required this.overviews,
+  });
+
+  /// User has not completed setup — no profile exists.
+  const CategoryBudgetOverviewState.notConfigured()
+      : this._(isConfigured: false, overviews: const []);
+
+  /// Setup exists but no categories have been created yet.
+  const CategoryBudgetOverviewState.noCategories()
+      : this._(isConfigured: true, overviews: const []);
+
+  /// Successfully loaded — [overviews] contains one entry per category.
+  const CategoryBudgetOverviewState.loaded(List<CategoryBudgetOverview> overviews)
+      : this._(isConfigured: true, overviews: overviews);
+
+  final bool isConfigured;
+
+  /// One [CategoryBudgetOverview] per user-created category, sorted by
+  /// sort_order as stored in the database.
+  final List<CategoryBudgetOverview> overviews;
+
+  bool get hasCategories => overviews.isNotEmpty;
+}
+
+// ── Provider ─────────────────────────────────────────────────────────────────
+
+final categoryBudgetOverviewProvider = AsyncNotifierProvider<
+    CategoryBudgetOverviewNotifier, CategoryBudgetOverviewState>(
+  CategoryBudgetOverviewNotifier.new,
+);
+
+// ── Notifier ─────────────────────────────────────────────────────────────────
+
+class CategoryBudgetOverviewNotifier
+    extends AsyncNotifier<CategoryBudgetOverviewState> {
+  @override
+  Future<CategoryBudgetOverviewState> build() => _load();
+
+  Future<void> refresh() async {
+    state = const AsyncLoading();
+    state = await AsyncValue.guard(_load);
+  }
+
+  Future<CategoryBudgetOverviewState> _load() async {
+    final setupDataSource = SetupLocalDataSource(
+      appDatabase: ref.read(appDatabaseProvider),
+    );
+    final expenseDataSource = ref.read(expenseLocalDataSourceProvider);
+    const service = BudgetRebalancingService();
+
+    final profile = await setupDataSource.getBudgetProfile();
+    if (profile == null) {
+      return const CategoryBudgetOverviewState.notConfigured();
+    }
+
+    final categories = await setupDataSource.getBudgetCategories();
+    if (categories.isEmpty) {
+      return const CategoryBudgetOverviewState.noCategories();
+    }
+
+    final now = DateTime.now();
+
+    final overviews = <CategoryBudgetOverview>[];
+    for (final category in categories) {
+      if (category.id == null) continue;
+
+      final expenses = await expenseDataSource.getExpensesForCategoryInMonth(
+        category.id!,
+        now,
+      );
+      final spentAmount = expenses.fold<double>(0, (sum, e) => sum + e.amount);
+
+      overviews.add(
+        service.calculate(
+          categoryId: category.id!,
+          categoryName: category.name,
+          plannedAmount: category.plannedAmount,
+          spentAmount: spentAmount,
+          now: now,
+        ),
+      );
+    }
+
+    return CategoryBudgetOverviewState.loaded(overviews);
+  }
+}

--- a/lib/shared/widgets/app_bottom_nav.dart
+++ b/lib/shared/widgets/app_bottom_nav.dart
@@ -31,9 +31,9 @@ class AppBottomNav extends StatelessWidget {
               label: 'Lisa kulu',
             ),
             NavigationDestination(
-              icon: Icon(Icons.shopping_basket_outlined),
-              selectedIcon: Icon(Icons.shopping_basket),
-              label: 'Toit',
+              icon: Icon(Icons.category_outlined),
+              selectedIcon: Icon(Icons.category),
+              label: 'Kategooriad',
             ),
             NavigationDestination(
               icon: Icon(Icons.settings_outlined),

--- a/test/features/grocery/domain/services/budget_rebalancing_service_test.dart
+++ b/test/features/grocery/domain/services/budget_rebalancing_service_test.dart
@@ -1,0 +1,293 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:safespender/features/grocery/domain/models/category_budget_status.dart';
+import 'package:safespender/features/grocery/domain/services/budget_rebalancing_service.dart';
+
+void main() {
+  const service = BudgetRebalancingService();
+
+  // Mid-month date where elapsed == 15 out of 31 days (July)
+  final july15 = DateTime(2025, 7, 15); // 15/31 ≈ 48% elapsed
+
+  group('BudgetRebalancingService.calculate', () {
+    group('remaining amount', () {
+      test('is planned minus spent', () {
+        final result = service.calculate(
+          categoryId: 1,
+          categoryName: 'Toit',
+          plannedAmount: 200,
+          spentAmount: 80,
+          now: july15,
+        );
+        expect(result.remainingAmount, closeTo(120.0, 0.01));
+      });
+
+      test('is negative when spent exceeds planned', () {
+        final result = service.calculate(
+          categoryId: 1,
+          categoryName: 'Toit',
+          plannedAmount: 200,
+          spentAmount: 230,
+          now: july15,
+        );
+        expect(result.remainingAmount, closeTo(-30.0, 0.01));
+        expect(result.overspentAmount, closeTo(30.0, 0.01));
+      });
+
+      test('overspentAmount is 0 when within budget', () {
+        final result = service.calculate(
+          categoryId: 1,
+          categoryName: 'Toit',
+          plannedAmount: 200,
+          spentAmount: 50,
+          now: july15,
+        );
+        expect(result.overspentAmount, 0.0);
+      });
+    });
+
+    group('period fields', () {
+      test('totalDaysInMonth is correct for July', () {
+        final result = service.calculate(
+          categoryId: 1,
+          categoryName: 'Toit',
+          plannedAmount: 200,
+          spentAmount: 50,
+          now: july15,
+        );
+        expect(result.totalDaysInMonth, 31);
+      });
+
+      test('elapsedDays equals day-of-month', () {
+        final result = service.calculate(
+          categoryId: 1,
+          categoryName: 'Toit',
+          plannedAmount: 200,
+          spentAmount: 50,
+          now: july15,
+        );
+        expect(result.elapsedDays, 15);
+      });
+
+      test('remainingDays is totalDays minus elapsedDays', () {
+        final result = service.calculate(
+          categoryId: 1,
+          categoryName: 'Toit',
+          plannedAmount: 200,
+          spentAmount: 50,
+          now: july15,
+        );
+        expect(result.remainingDays, 16); // 31 - 15
+      });
+
+      test('last day of month gives 0 remaining days', () {
+        final lastDay = _date(2025, 7, 31);
+        final result = service.calculate(
+          categoryId: 1,
+          categoryName: 'Toit',
+          plannedAmount: 200,
+          spentAmount: 50,
+          now: lastDay,
+        );
+        expect(result.remainingDays, 0);
+      });
+
+      test('works correctly for February in a leap year', () {
+        final feb29 = _date(2024, 2, 29);
+        final result = service.calculate(
+          categoryId: 1,
+          categoryName: 'Toit',
+          plannedAmount: 200,
+          spentAmount: 0,
+          now: feb29,
+        );
+        expect(result.totalDaysInMonth, 29);
+        expect(result.remainingDays, 0);
+      });
+    });
+
+    group('status — onTrack', () {
+      test('returns onTrack when spending matches expected pace', () {
+        // 15/31 days elapsed → ~48% of month gone. Spending 48% of 200 = 96.
+        final result = service.calculate(
+          categoryId: 1,
+          categoryName: 'Toit',
+          plannedAmount: 200,
+          spentAmount: 96,
+          now: july15,
+        );
+        expect(result.status, CategoryBudgetStatus.onTrack);
+        expect(result.isOverBudget, isFalse);
+      });
+    });
+
+    group('status — underBudget', () {
+      test('returns underBudget when spending is well below expected pace', () {
+        // 15/31 elapsed, expected ≈ 96.77. 80% of that ≈ 77.4.
+        // Spending 20 is well below the threshold.
+        final result = service.calculate(
+          categoryId: 1,
+          categoryName: 'Toit',
+          plannedAmount: 200,
+          spentAmount: 20,
+          now: july15,
+        );
+        expect(result.status, CategoryBudgetStatus.underBudget);
+      });
+
+      test('returns underBudget on first day with zero spending', () {
+        final firstDay = _date(2025, 7, 1);
+        final result = service.calculate(
+          categoryId: 1,
+          categoryName: 'Toit',
+          plannedAmount: 200,
+          spentAmount: 0,
+          now: firstDay,
+        );
+        // 1/31 elapsed, expected ≈ 6.45. 0 < 6.45 * 0.8 → underBudget.
+        expect(result.status, CategoryBudgetStatus.underBudget);
+      });
+    });
+
+    group('status — nearLimit', () {
+      test('returns nearLimit when usage >= 85% and not yet over', () {
+        // 85% of 200 = 170
+        final result = service.calculate(
+          categoryId: 1,
+          categoryName: 'Toit',
+          plannedAmount: 200,
+          spentAmount: 170,
+          now: july15,
+        );
+        expect(result.status, CategoryBudgetStatus.nearLimit);
+        expect(result.isOverBudget, isFalse);
+      });
+
+      test('returns nearLimit at exactly 85% usage', () {
+        final result = service.calculate(
+          categoryId: 1,
+          categoryName: 'Toit',
+          plannedAmount: 100,
+          spentAmount: 85,
+          now: july15,
+        );
+        expect(result.status, CategoryBudgetStatus.nearLimit);
+      });
+    });
+
+    group('status — overBudget', () {
+      test('returns overBudget when spent exceeds planned', () {
+        final result = service.calculate(
+          categoryId: 1,
+          categoryName: 'Toit',
+          plannedAmount: 200,
+          spentAmount: 201,
+          now: july15,
+        );
+        expect(result.status, CategoryBudgetStatus.overBudget);
+        expect(result.isOverBudget, isTrue);
+      });
+
+      test('overBudget takes priority over nearLimit threshold', () {
+        // If remaining < 0, must be overBudget regardless of usagePercent.
+        final result = service.calculate(
+          categoryId: 1,
+          categoryName: 'Toit',
+          plannedAmount: 100,
+          spentAmount: 110,
+          now: july15,
+        );
+        expect(result.status, CategoryBudgetStatus.overBudget);
+      });
+    });
+
+    group('daily suggestion', () {
+      test('is remaining divided by remaining days when under budget', () {
+        // remaining = 120, remainingDays = 16 → 7.50
+        final result = service.calculate(
+          categoryId: 1,
+          categoryName: 'Toit',
+          plannedAmount: 200,
+          spentAmount: 80,
+          now: july15,
+        );
+        expect(result.suggestedDailyAmount, closeTo(7.50, 0.01));
+      });
+
+      test('is null when overBudget', () {
+        final result = service.calculate(
+          categoryId: 1,
+          categoryName: 'Toit',
+          plannedAmount: 200,
+          spentAmount: 250,
+          now: july15,
+        );
+        expect(result.suggestedDailyAmount, isNull);
+      });
+
+      test('is null on the last day of the month (0 remaining days)', () {
+        final lastDay = _date(2025, 7, 31);
+        final result = service.calculate(
+          categoryId: 1,
+          categoryName: 'Toit',
+          plannedAmount: 200,
+          spentAmount: 80,
+          now: lastDay,
+        );
+        expect(result.suggestedDailyAmount, isNull);
+      });
+
+      test('rounds to 2 decimal places', () {
+        // remaining = 100, remainingDays = 16 → 6.25 (exact)
+        final result = service.calculate(
+          categoryId: 1,
+          categoryName: 'Toit',
+          plannedAmount: 180,
+          spentAmount: 80,
+          now: july15,
+        );
+        // remaining = 100, days = 16 → 6.25
+        expect(result.suggestedDailyAmount, closeTo(6.25, 0.001));
+      });
+    });
+
+    group('edge cases', () {
+      test('handles zero planned amount without crashing', () {
+        final result = service.calculate(
+          categoryId: 1,
+          categoryName: 'Toit',
+          plannedAmount: 0,
+          spentAmount: 50,
+          now: july15,
+        );
+        // usagePercent clamps to 2.0 when planned is 0 and spent > 0
+        expect(result.usagePercent, 2.0);
+        expect(result.status, CategoryBudgetStatus.overBudget);
+      });
+
+      test('handles zero spent without crashing', () {
+        final result = service.calculate(
+          categoryId: 1,
+          categoryName: 'Toit',
+          plannedAmount: 200,
+          spentAmount: 0,
+          now: july15,
+        );
+        expect(result.spentAmount, 0.0);
+        expect(result.remainingAmount, closeTo(200.0, 0.01));
+      });
+
+      test('usagePercent is 0 when both planned and spent are 0', () {
+        final result = service.calculate(
+          categoryId: 1,
+          categoryName: 'Toit',
+          plannedAmount: 0,
+          spentAmount: 0,
+          now: july15,
+        );
+        expect(result.usagePercent, 0.0);
+      });
+    });
+  });
+}
+
+DateTime _date(int year, int month, int day) => DateTime(year, month, day);


### PR DESCRIPTION
Closes #11 

Implemented the grocery budget overview with actual vs planned tracking, remaining amount, and rebalancing recommendation logic. Moved the calculation part into domain so the UI just displays the state, and wired it into the app flow so it feels like a real core feature instead of a placeholder.