### PR TITLE
add editable settings flow and profile preferences

### DIFF
--- a/lib/core/database/app_database.dart
+++ b/lib/core/database/app_database.dart
@@ -10,7 +10,7 @@ class AppDatabase {
   static final AppDatabase instance = AppDatabase._();
 
   static const _databaseName = 'bigbank_budget.db';
-  static const _databaseVersion = 2;
+  static const _databaseVersion = 3;
 
   Database? _database;
 
@@ -71,12 +71,25 @@ class AppDatabase {
     ''');
 
     await _createExpensesTable(db);
+    await _createAppPreferencesTable(db);
   }
 
   Future<void> _onUpgrade(Database db, int oldVersion, int newVersion) async {
     if (oldVersion < 2) {
       await _createExpensesTable(db);
     }
+    if (oldVersion < 3) {
+      await _createAppPreferencesTable(db);
+    }
+  }
+
+  Future<void> _createAppPreferencesTable(Database db) async {
+    await db.execute('''
+      CREATE TABLE IF NOT EXISTS app_preferences (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL
+      )
+    ''');
   }
 
   Future<void> _createExpensesTable(Database db) async {

--- a/lib/features/settings/data/datasources/settings_local_data_source.dart
+++ b/lib/features/settings/data/datasources/settings_local_data_source.dart
@@ -1,0 +1,37 @@
+import 'package:sqflite/sqflite.dart';
+
+import '../../../../core/database/app_database.dart';
+import '../../domain/models/app_preferences.dart';
+
+class SettingsLocalDataSource {
+  final AppDatabase appDatabase;
+
+  const SettingsLocalDataSource({required this.appDatabase});
+
+  Future<AppPreferences> getPreferences() async {
+    final db = await appDatabase.database;
+    final rows = await db.query('app_preferences');
+
+    final map = <String, String>{
+      for (final row in rows)
+        row['key'] as String: row['value'] as String,
+    };
+
+    return AppPreferences.fromKeyValueMap(map);
+  }
+
+  Future<void> savePreferences(AppPreferences preferences) async {
+    final db = await appDatabase.database;
+    final kvMap = preferences.toKeyValueMap();
+
+    await db.transaction((txn) async {
+      for (final entry in kvMap.entries) {
+        await txn.insert(
+          'app_preferences',
+          {'key': entry.key, 'value': entry.value},
+          conflictAlgorithm: ConflictAlgorithm.replace,
+        );
+      }
+    });
+  }
+}

--- a/lib/features/settings/data/repositories/settings_repository.dart
+++ b/lib/features/settings/data/repositories/settings_repository.dart
@@ -1,0 +1,6 @@
+import '../../domain/models/app_preferences.dart';
+
+abstract class SettingsRepository {
+  Future<AppPreferences> getPreferences();
+  Future<void> savePreferences(AppPreferences preferences);
+}

--- a/lib/features/settings/data/repositories/settings_repository_impl.dart
+++ b/lib/features/settings/data/repositories/settings_repository_impl.dart
@@ -1,0 +1,19 @@
+import '../../domain/models/app_preferences.dart';
+import '../datasources/settings_local_data_source.dart';
+import 'settings_repository.dart';
+
+class SettingsRepositoryImpl implements SettingsRepository {
+  final SettingsLocalDataSource localDataSource;
+
+  const SettingsRepositoryImpl({required this.localDataSource});
+
+  @override
+  Future<AppPreferences> getPreferences() {
+    return localDataSource.getPreferences();
+  }
+
+  @override
+  Future<void> savePreferences(AppPreferences preferences) {
+    return localDataSource.savePreferences(preferences);
+  }
+}

--- a/lib/features/settings/domain/models/app_preferences.dart
+++ b/lib/features/settings/domain/models/app_preferences.dart
@@ -1,0 +1,29 @@
+class AppPreferences {
+  final bool notificationsEnabled;
+
+  const AppPreferences({
+    this.notificationsEnabled = false,
+  });
+
+  AppPreferences copyWith({bool? notificationsEnabled}) {
+    return AppPreferences(
+      notificationsEnabled: notificationsEnabled ?? this.notificationsEnabled,
+    );
+  }
+
+  static const _keyNotifications = 'notifications_enabled';
+
+  Map<String, String> toKeyValueMap() {
+    return {
+      _keyNotifications: notificationsEnabled ? '1' : '0',
+    };
+  }
+
+  factory AppPreferences.fromKeyValueMap(Map<String, String> map) {
+    return AppPreferences(
+      notificationsEnabled: map[_keyNotifications] == '1',
+    );
+  }
+
+  static const AppPreferences defaults = AppPreferences();
+}

--- a/lib/features/settings/presentation/providers/settings_notifier.dart
+++ b/lib/features/settings/presentation/providers/settings_notifier.dart
@@ -1,0 +1,328 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../grocery/presentation/providers/grocery_overview_provider.dart';
+import '../../../home/presentation/providers/home_summary_provider.dart';
+import '../../../purchase_check/presentation/providers/purchase_check_notifier.dart';
+import '../../../setup/data/repositories/setup_repository.dart';
+import '../../../setup/domain/models/budget_category.dart';
+import '../../../setup/domain/services/setup_budget_calculator.dart';
+import '../../../setup/presentation/providers/setup_notifier.dart';
+import '../../data/datasources/settings_local_data_source.dart';
+import '../../data/repositories/settings_repository.dart';
+import '../../data/repositories/settings_repository_impl.dart';
+import 'settings_state.dart';
+
+// ── Providers ─────────────────────────────────────────────────────────────────
+
+final _settingsLocalDataSourceProvider =
+    Provider<SettingsLocalDataSource>((ref) {
+  return SettingsLocalDataSource(
+    appDatabase: ref.watch(appDatabaseProvider),
+  );
+});
+
+final _settingsRepositoryProvider = Provider<SettingsRepository>((ref) {
+  return SettingsRepositoryImpl(
+    localDataSource: ref.watch(_settingsLocalDataSourceProvider),
+  );
+});
+
+final settingsNotifierProvider =
+    NotifierProvider<SettingsNotifier, SettingsState>(SettingsNotifier.new);
+
+// ── Notifier ──────────────────────────────────────────────────────────────────
+
+class SettingsNotifier extends Notifier<SettingsState> {
+  late final SetupRepository _setupRepository;
+  late final SettingsRepository _settingsRepository;
+  late final SetupBudgetCalculator _calculator;
+
+  @override
+  SettingsState build() {
+    _setupRepository = ref.read(setupRepositoryProvider);
+    _settingsRepository = ref.read(_settingsRepositoryProvider);
+    _calculator = ref.read(setupBudgetCalculatorProvider);
+    return SettingsState.initial();
+  }
+
+  // ── Load ──────────────────────────────────────────────────────────────────
+
+  Future<void> loadCurrentSettings() async {
+    state = state.copyWith(isLoading: true, clearErrorMessage: true);
+
+    try {
+      final profile = await _setupRepository.getBudgetProfile();
+      final preferences = await _settingsRepository.getPreferences();
+      final categories = await _setupRepository.getBudgetCategories();
+
+      if (profile == null) {
+        state = state.copyWith(
+          isLoading: false,
+          hasProfile: false,
+          notificationsEnabled: preferences.notificationsEnabled,
+        );
+        return;
+      }
+
+      state = state.copyWith(
+        isLoading: false,
+        hasProfile: true,
+        safetyBufferInput: _fmt(profile.safetyBuffer),
+        currencyCode: profile.currencyCode,
+        categories: categories,
+        notificationsEnabled: preferences.notificationsEnabled,
+        monthlyIncome: profile.monthlyIncome,
+        monthlyFixedExpenses: profile.monthlyFixedExpenses,
+        distributableAmount: profile.distributableAmount,
+      );
+    } catch (e, st) {
+      debugPrint('SettingsNotifier.load error: $e');
+      debugPrintStack(stackTrace: st);
+      state = state.copyWith(
+        isLoading: false,
+        errorMessage: 'Seadete laadimine ebaõnnestus.',
+      );
+    }
+  }
+
+  // ── Profile field updates ─────────────────────────────────────────────────
+
+  void updateSafetyBufferInput(String value) {
+    state = state.copyWith(
+      safetyBufferInput: value,
+      clearErrorMessage: true,
+      clearSuccessMessage: true,
+    );
+  }
+
+  void updateCurrencyCode(String code) {
+    state = state.copyWith(
+      currencyCode: code,
+      clearErrorMessage: true,
+      clearSuccessMessage: true,
+    );
+  }
+
+  // ── Category management ───────────────────────────────────────────────────
+
+  void addCategory(String name) {
+    final trimmed = name.trim();
+    if (trimmed.isEmpty) return;
+    if (state.categories.length >= 5) {
+      state = state.copyWith(errorMessage: 'Maksimaalselt 5 kategooriat.');
+      return;
+    }
+    final alreadyExists = state.categories
+        .any((c) => c.name.toLowerCase() == trimmed.toLowerCase());
+    if (alreadyExists) {
+      state =
+          state.copyWith(errorMessage: 'Selline kategooria on juba olemas.');
+      return;
+    }
+
+    final now = DateTime.now();
+    final updated = [
+      ...state.categories,
+      BudgetCategory(
+        name: trimmed,
+        allocationPercent: 0,
+        plannedAmount: 0,
+        sortOrder: state.categories.length,
+        isDefault: false,
+        createdAt: now,
+        updatedAt: now,
+      ),
+    ];
+
+    state = state.copyWith(
+      categories: updated,
+      clearErrorMessage: true,
+      clearSuccessMessage: true,
+    );
+  }
+
+  void removeCategory(int index) {
+    if (index < 0 || index >= state.categories.length) return;
+    if (state.categories[index].isDefault) {
+      state = state.copyWith(
+          errorMessage: 'Vaikimisi kategooriat ei saa eemaldada.');
+      return;
+    }
+
+    final updated = [...state.categories]..removeAt(index);
+    state = state.copyWith(
+      categories: _rebuildSortOrders(updated),
+      clearErrorMessage: true,
+      clearSuccessMessage: true,
+    );
+  }
+
+  void updateCategoryName(int index, String name) {
+    final trimmed = name.trim();
+    if (trimmed.isEmpty || index < 0 || index >= state.categories.length) {
+      return;
+    }
+    final alreadyExists = state.categories.asMap().entries.any(
+      (e) =>
+          e.key != index &&
+          e.value.name.toLowerCase() == trimmed.toLowerCase(),
+    );
+    if (alreadyExists) {
+      state =
+          state.copyWith(errorMessage: 'Selline kategooria on juba olemas.');
+      return;
+    }
+
+    final updated = [...state.categories];
+    updated[index] = updated[index].copyWith(
+      name: trimmed,
+      updatedAt: DateTime.now(),
+    );
+    state = state.copyWith(
+      categories: updated,
+      clearErrorMessage: true,
+      clearSuccessMessage: true,
+    );
+  }
+
+  void updateCategoryAllocationPercent(int index, double newPercent) {
+    if (index < 0 || index >= state.categories.length) return;
+
+    final otherTotal = state.categories
+        .asMap()
+        .entries
+        .where((e) => e.key != index)
+        .fold<double>(0, (s, e) => s + e.value.allocationPercent);
+
+    final max = 100.0 - otherTotal;
+    final clamped = newPercent.clamp(0.0, max < 0 ? 0.0 : max);
+    final rounded = double.parse(clamped.toStringAsFixed(2));
+
+    final updated = [...state.categories];
+    updated[index] = updated[index].copyWith(
+      allocationPercent: rounded,
+      updatedAt: DateTime.now(),
+    );
+    state = state.copyWith(
+      categories: updated,
+      clearErrorMessage: true,
+      clearSuccessMessage: true,
+    );
+  }
+
+  // ── Preferences ───────────────────────────────────────────────────────────
+
+  void toggleNotifications(bool enabled) {
+    state = state.copyWith(notificationsEnabled: enabled);
+    _persistPreferences();
+  }
+
+  // ── Save ──────────────────────────────────────────────────────────────────
+
+  Future<void> saveChanges() async {
+    if (!state.isFormValid) {
+      state = state.copyWith(errorMessage: _validationError());
+      return;
+    }
+
+    state = state.copyWith(
+      isSaving: true,
+      clearErrorMessage: true,
+      clearSuccessMessage: true,
+    );
+
+    try {
+      final existing = await _setupRepository.getBudgetProfile();
+      if (existing == null) {
+        state = state.copyWith(
+          isSaving: false,
+          errorMessage: 'Eelarveprofiil puudub. Seadistage esmalt rakendus.',
+        );
+        return;
+      }
+
+      // Build updated profile, preserving income + fixed expenses from DB
+      final updatedProfile = _calculator.buildBudgetProfile(
+        id: existing.id,
+        monthlyIncome: existing.monthlyIncome,
+        monthlyFixedExpenses: existing.monthlyFixedExpenses,
+        safetyBuffer: state.safetyBuffer,
+        currencyCode: state.currencyCode,
+        createdAt: existing.createdAt,
+      );
+
+      await _setupRepository.updateBudgetProfile(updatedProfile);
+
+      await _setupRepository.syncCategories(
+        profileId: existing.id!,
+        distributableAmount: updatedProfile.distributableAmount,
+        categories: state.categories,
+      );
+
+      // Update local distributableAmount to reflect new safetyBuffer
+      state = state.copyWith(
+        distributableAmount: updatedProfile.distributableAmount,
+      );
+
+      ref.invalidate(homeSummaryProvider);
+      ref.invalidate(categoryBudgetOverviewProvider);
+      ref.invalidate(purchaseCheckProvider);
+
+      state = state.copyWith(
+        isSaving: false,
+        successMessage: 'Seaded salvestatud.',
+      );
+    } catch (e, st) {
+      debugPrint('SettingsNotifier.save error: $e');
+      debugPrintStack(stackTrace: st);
+      state = state.copyWith(
+        isSaving: false,
+        errorMessage: 'Salvestamine ebaõnnestus. Proovi uuesti.',
+      );
+    }
+  }
+
+  void clearMessages() {
+    state = state.copyWith(
+      clearErrorMessage: true,
+      clearSuccessMessage: true,
+    );
+  }
+
+  // ── Helpers ───────────────────────────────────────────────────────────────
+
+  Future<void> _persistPreferences() async {
+    try {
+      final current = await _settingsRepository.getPreferences();
+      await _settingsRepository.savePreferences(
+        current.copyWith(notificationsEnabled: state.notificationsEnabled),
+      );
+    } catch (e) {
+      debugPrint('SettingsNotifier._persistPreferences error: $e');
+    }
+  }
+
+  String? _validationError() {
+    if (state.safetyBuffer < 0) return 'Puhver ei saa olla negatiivne.';
+    final newDistributable =
+        state.monthlyIncome - state.monthlyFixedExpenses - state.safetyBuffer;
+    if (newDistributable <= 0) {
+      return 'Pärast püsikulusid ja puhvrit peab jääma jagatav summa.';
+    }
+    if (state.totalAllocatedPercent > 100) {
+      return 'Kategooriate protsendid ületavad 100%.';
+    }
+    return null;
+  }
+
+  List<BudgetCategory> _rebuildSortOrders(List<BudgetCategory> cats) {
+    final now = DateTime.now();
+    return List.generate(
+      cats.length,
+      (i) => cats[i].copyWith(sortOrder: i, updatedAt: now),
+    );
+  }
+
+  String _fmt(double value) => value.toStringAsFixed(2);
+}

--- a/lib/features/settings/presentation/providers/settings_state.dart
+++ b/lib/features/settings/presentation/providers/settings_state.dart
@@ -1,0 +1,131 @@
+import '../../../setup/domain/models/budget_category.dart';
+
+class SettingsState {
+  final bool isLoading;
+  final bool isSaving;
+  final bool hasProfile;
+  final String? errorMessage;
+  final String? successMessage;
+
+  // Profile fields (edited in bottom sheets)
+  final String safetyBufferInput;
+  final String currencyCode;
+
+  // Categories (edited inline / bottom sheet)
+  final List<BudgetCategory> categories;
+
+  // Preferences
+  final bool notificationsEnabled;
+
+  // Computed from profile (read-only, set on load)
+  final double monthlyIncome;
+  final double monthlyFixedExpenses;
+  final double distributableAmount;
+
+  const SettingsState({
+    required this.isLoading,
+    required this.isSaving,
+    required this.hasProfile,
+    this.errorMessage,
+    this.successMessage,
+    this.safetyBufferInput = '',
+    this.currencyCode = 'EUR',
+    this.categories = const [],
+    this.notificationsEnabled = false,
+    this.monthlyIncome = 0,
+    this.monthlyFixedExpenses = 0,
+    this.distributableAmount = 0,
+  });
+
+  factory SettingsState.initial() {
+    return const SettingsState(
+      isLoading: true,
+      isSaving: false,
+      hasProfile: false,
+    );
+  }
+
+  double get safetyBuffer =>
+      double.tryParse(safetyBufferInput.replaceAll(',', '.').trim()) ?? 0;
+
+  double get totalAllocatedPercent {
+    final total =
+        categories.fold<double>(0, (s, c) => s + c.allocationPercent);
+    return double.parse(total.toStringAsFixed(2));
+  }
+
+  double get unallocatedPercent {
+    final left = 100.0 - totalAllocatedPercent;
+    return left < 0 ? 0 : double.parse(left.toStringAsFixed(2));
+  }
+
+  bool get isFormValid {
+    if (safetyBuffer < 0) return false;
+    final newDistributable =
+        monthlyIncome - monthlyFixedExpenses - safetyBuffer;
+    if (newDistributable <= 0) return false;
+    if (totalAllocatedPercent > 100) return false;
+    return true;
+  }
+
+  /// Currency symbol for display.
+  String get currencySymbol {
+    switch (currencyCode) {
+      case 'USD':
+        return '\$';
+      case 'GBP':
+        return '£';
+      default:
+        return '€';
+    }
+  }
+
+  /// Human-readable currency label shown in the row.
+  String get currencyLabel {
+    switch (currencyCode) {
+      case 'USD':
+        return 'Dollar - USD';
+      case 'GBP':
+        return 'Naelsterling - GBP';
+      default:
+        return 'Euro - EUR';
+    }
+  }
+
+  SettingsState copyWith({
+    bool? isLoading,
+    bool? isSaving,
+    bool? hasProfile,
+    String? errorMessage,
+    String? successMessage,
+    String? safetyBufferInput,
+    String? currencyCode,
+    List<BudgetCategory>? categories,
+    bool? notificationsEnabled,
+    double? monthlyIncome,
+    double? monthlyFixedExpenses,
+    double? distributableAmount,
+    bool clearErrorMessage = false,
+    bool clearSuccessMessage = false,
+  }) {
+    return SettingsState(
+      isLoading: isLoading ?? this.isLoading,
+      isSaving: isSaving ?? this.isSaving,
+      hasProfile: hasProfile ?? this.hasProfile,
+      errorMessage:
+          clearErrorMessage ? null : (errorMessage ?? this.errorMessage),
+      successMessage: clearSuccessMessage
+          ? null
+          : (successMessage ?? this.successMessage),
+      safetyBufferInput: safetyBufferInput ?? this.safetyBufferInput,
+      currencyCode: currencyCode ?? this.currencyCode,
+      categories: categories ?? this.categories,
+      notificationsEnabled:
+          notificationsEnabled ?? this.notificationsEnabled,
+      monthlyIncome: monthlyIncome ?? this.monthlyIncome,
+      monthlyFixedExpenses:
+          monthlyFixedExpenses ?? this.monthlyFixedExpenses,
+      distributableAmount: distributableAmount ?? this.distributableAmount,
+    );
+  }
+}

--- a/lib/features/settings/presentation/settings_screen.dart
+++ b/lib/features/settings/presentation/settings_screen.dart
@@ -1,19 +1,1198 @@
 import 'package:flutter/material.dart';
-import 'package:go_router/go_router.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-class SettingsScreen extends StatelessWidget {
+import '../../../app/theme/app_colors.dart';
+import '../../../features/setup/domain/models/budget_category.dart';
+import 'providers/settings_notifier.dart';
+import 'providers/settings_state.dart';
+
+class SettingsScreen extends ConsumerStatefulWidget {
   const SettingsScreen({super.key});
 
   @override
+  ConsumerState<SettingsScreen> createState() => _SettingsScreenState();
+}
+
+class _SettingsScreenState extends ConsumerState<SettingsScreen> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      ref.read(settingsNotifierProvider.notifier).loadCurrentSettings();
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final state = ref.watch(settingsNotifierProvider);
+    final notifier = ref.read(settingsNotifierProvider.notifier);
+
+    ref.listen(settingsNotifierProvider, (prev, next) {
+      if (next.successMessage != null &&
+          next.successMessage != prev?.successMessage) {
+        ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+          content: Text(next.successMessage!),
+          backgroundColor: AppColors.success,
+          behavior: SnackBarBehavior.floating,
+        ));
+        notifier.clearMessages();
+      }
+      if (next.errorMessage != null &&
+          next.errorMessage != prev?.errorMessage) {
+        ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+          content: Text(next.errorMessage!),
+          backgroundColor: AppColors.error,
+          behavior: SnackBarBehavior.floating,
+        ));
+        notifier.clearMessages();
+      }
+    });
+
     return Scaffold(
+      backgroundColor: AppColors.background,
       appBar: AppBar(
-        title: const Text('settings screen jne')
+        backgroundColor: AppColors.background.withValues(alpha: 0.85),
+        elevation: 0,
+        surfaceTintColor: Colors.transparent,
+        title: const Text(
+          'Seaded',
+          style: TextStyle(
+            color: AppColors.textPrimary,
+            fontSize: 20,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+        centerTitle: false,
+        bottom: PreferredSize(
+          preferredSize: const Size.fromHeight(28),
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(20, 0, 20, 12),
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: Text(
+                'Halda oma eelarve eelistusi ja jaotust',
+                style: TextStyle(
+                  color: AppColors.textSecondary,
+                  fontSize: 13,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+            ),
+          ),
+        ),
       ),
-      body: Center(
-        child: ElevatedButton(
-          onPressed: () => context.go('/'),
-          child: const Text('tagasi pealehele ss'),
+      body: state.isLoading
+          ? const Center(child: CircularProgressIndicator())
+          : Column(
+              children: [
+                Expanded(
+                  child: ListView(
+                    padding: const EdgeInsets.fromLTRB(20, 16, 20, 8),
+                    children: [
+                      if (!state.hasProfile) ...[
+                        _NoProfileBanner(),
+                        const SizedBox(height: 24),
+                      ],
+                      if (state.hasProfile) ...[
+                        _sectionLabel('Eelarve seaded'),
+                        const SizedBox(height: 12),
+                        _BudgetSettingsCard(
+                            state: state, notifier: notifier),
+                        const SizedBox(height: 24),
+                        _CategorySectionHeader(state: state),
+                        const SizedBox(height: 12),
+                        _CategoryListCard(
+                            state: state, notifier: notifier),
+                        const SizedBox(height: 8),
+                        _AddCategoryButton(notifier: notifier),
+                        const SizedBox(height: 24),
+                      ],
+                      _sectionLabel('Eelistused'),
+                      const SizedBox(height: 12),
+                      _NotificationsCard(
+                          state: state, notifier: notifier),
+                      const SizedBox(height: 24),
+                      _DataSecurityCard(),
+                      const SizedBox(height: 8),
+                    ],
+                  ),
+                ),
+                if (state.hasProfile)
+                  _SaveButton(state: state, notifier: notifier),
+              ],
+            ),
+    );
+  }
+
+  Widget _sectionLabel(String title) {
+    return Padding(
+      padding: const EdgeInsets.only(left: 2),
+      child: Text(
+        title.toUpperCase(),
+        style: const TextStyle(
+          color: AppColors.textSecondary,
+          fontSize: 11,
+          fontWeight: FontWeight.w800,
+          letterSpacing: 1.2,
+        ),
+      ),
+    );
+  }
+}
+
+// ── Eelarve seaded card ────────────────────────────────────────────────────────
+
+class _BudgetSettingsCard extends StatelessWidget {
+  final SettingsState state;
+  final SettingsNotifier notifier;
+
+  const _BudgetSettingsCard(
+      {required this.state, required this.notifier});
+
+  @override
+  Widget build(BuildContext context) {
+    return _Card(
+      children: [
+        _TappableRow(
+          label: 'Puhver',
+          subtitle: 'Igakuine reservfond',
+          value:
+              '${state.safetyBuffer.toStringAsFixed(2).replaceAll('.', ',')} ${state.currencySymbol}',
+          onTap: () => _showBufferSheet(context),
+        ),
+        const _RowDivider(),
+        _TappableRow(
+          label: 'Valuuta',
+          subtitle: 'Vaikimisi valuuta tehingutele',
+          value: state.currencyLabel,
+          onTap: () => _showCurrencySheet(context),
+        ),
+      ],
+    );
+  }
+
+  void _showBufferSheet(BuildContext context) {
+    final controller = TextEditingController(
+      text: state.safetyBuffer > 0
+          ? state.safetyBuffer.toStringAsFixed(2).replaceAll('.', ',')
+          : '',
+    );
+
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (_) => _BottomSheetContainer(
+        title: 'Turvapuhver',
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              'Summa, mida iga kuu kõrvale paned',
+              style: TextStyle(color: AppColors.textSecondary, fontSize: 13),
+            ),
+            const SizedBox(height: 16),
+            _AmountField(controller: controller),
+            const SizedBox(height: 24),
+            _SheetSaveButton(
+              label: 'Kinnita',
+              onTap: () {
+                notifier.updateSafetyBufferInput(controller.text);
+                Navigator.pop(context);
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _showCurrencySheet(BuildContext context) {
+    showModalBottomSheet(
+      context: context,
+      backgroundColor: Colors.transparent,
+      builder: (_) => StatefulBuilder(
+        builder: (ctx, setModalState) => _BottomSheetContainer(
+          title: 'Valuuta',
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              for (final option in [
+                ('EUR', 'Euro', '€'),
+                ('USD', 'Ameerika dollar', '\$'),
+                ('GBP', 'Naelsterling', '£'),
+              ])
+                _CurrencyOption(
+                  code: option.$1,
+                  name: option.$2,
+                  symbol: option.$3,
+                  isSelected: state.currencyCode == option.$1,
+                  onTap: () {
+                    notifier.updateCurrencyCode(option.$1);
+                    Navigator.pop(context);
+                  },
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ── Category section header ────────────────────────────────────────────────────
+
+class _CategorySectionHeader extends StatelessWidget {
+  final SettingsState state;
+
+  const _CategorySectionHeader({required this.state});
+
+  @override
+  Widget build(BuildContext context) {
+    final pct = state.totalAllocatedPercent;
+    final isOver = pct > 100;
+    return Padding(
+      padding: const EdgeInsets.only(left: 2),
+      child: Row(
+        children: [
+          const Expanded(
+            child: Text(
+              'KATEGOORIATE HALDUS',
+              style: TextStyle(
+                color: AppColors.textSecondary,
+                fontSize: 11,
+                fontWeight: FontWeight.w800,
+                letterSpacing: 1.2,
+              ),
+            ),
+          ),
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+            decoration: BoxDecoration(
+              color: isOver
+                  ? AppColors.errorBg
+                  : AppColors.primarySoft,
+              borderRadius: BorderRadius.circular(20),
+            ),
+            child: Text(
+              'KOKKU: ${pct.toStringAsFixed(0)}%',
+              style: TextStyle(
+                color: isOver ? AppColors.error : AppColors.primary,
+                fontSize: 10,
+                fontWeight: FontWeight.w800,
+                letterSpacing: 0.5,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ── Category list card ────────────────────────────────────────────────────────
+
+class _CategoryListCard extends StatelessWidget {
+  final SettingsState state;
+  final SettingsNotifier notifier;
+
+  const _CategoryListCard(
+      {required this.state, required this.notifier});
+
+  @override
+  Widget build(BuildContext context) {
+    final cats = state.categories;
+    if (cats.isEmpty) {
+      return _Card(children: [
+        const Padding(
+          padding: EdgeInsets.all(16),
+          child: Text(
+            'Kategooriad puuduvad.',
+            style: TextStyle(color: AppColors.textSecondary, fontSize: 14),
+          ),
+        ),
+      ]);
+    }
+
+    // Build color opacities for segmented bar
+    final opacities = [1.0, 0.65, 0.45, 0.28, 0.15];
+
+    return _Card(
+      children: [
+        for (int i = 0; i < cats.length; i++) ...[
+          if (i > 0) const _RowDivider(),
+          _CategoryRow(
+            category: cats[i],
+            accentOpacity: opacities[i % opacities.length],
+            onEdit: () => _showEditSheet(context, i, cats[i]),
+          ),
+        ],
+        const _RowDivider(),
+        _AllocationBar(categories: cats),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
+          child: Text(
+            'Kokku jaotatud: ${state.totalAllocatedPercent.toStringAsFixed(0)}%'
+            '${state.unallocatedPercent > 0 ? '  •  Jaotamata: ${state.unallocatedPercent.toStringAsFixed(0)}%' : ''}',
+            textAlign: TextAlign.center,
+            style: const TextStyle(
+              color: AppColors.textSecondary,
+              fontSize: 11,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  void _showEditSheet(
+      BuildContext context, int index, BudgetCategory category) {
+    final nameCtrl = TextEditingController(text: category.name);
+    double localPercent = category.allocationPercent;
+
+    // Max = current + unallocated
+    final maxPercent =
+        category.allocationPercent + state.unallocatedPercent;
+
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (_) => StatefulBuilder(
+        builder: (ctx, setModalState) => _BottomSheetContainer(
+          title: category.isDefault
+              ? category.name
+              : 'Muuda kategooriat',
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              if (!category.isDefault) ...[
+                const Text(
+                  'Nimi',
+                  style: TextStyle(
+                      color: AppColors.textSecondary, fontSize: 12),
+                ),
+                const SizedBox(height: 6),
+                TextField(
+                  controller: nameCtrl,
+                  style: const TextStyle(
+                    color: AppColors.textPrimary,
+                    fontSize: 15,
+                    fontWeight: FontWeight.w600,
+                  ),
+                  decoration: InputDecoration(
+                    filled: true,
+                    fillColor: AppColors.inputFill,
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(10),
+                      borderSide: BorderSide.none,
+                    ),
+                    contentPadding: const EdgeInsets.symmetric(
+                        horizontal: 14, vertical: 12),
+                  ),
+                ),
+                const SizedBox(height: 20),
+              ],
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  const Text(
+                    'Osakaal',
+                    style: TextStyle(
+                        color: AppColors.textSecondary, fontSize: 12),
+                  ),
+                  Text(
+                    '${localPercent.toStringAsFixed(0)}%',
+                    style: const TextStyle(
+                      color: AppColors.primary,
+                      fontSize: 15,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                ],
+              ),
+              Slider(
+                value: localPercent,
+                min: 0,
+                max: maxPercent > 0 ? maxPercent : 100,
+                divisions: (maxPercent > 0 ? maxPercent : 100).round(),
+                activeColor: AppColors.primary,
+                inactiveColor: AppColors.primarySoft,
+                onChanged: (v) =>
+                    setModalState(() => localPercent = v),
+              ),
+              const SizedBox(height: 8),
+              Row(
+                children: [
+                  if (!category.isDefault)
+                    Expanded(
+                      child: OutlinedButton(
+                        onPressed: () {
+                          notifier.removeCategory(index);
+                          Navigator.pop(context);
+                        },
+                        style: OutlinedButton.styleFrom(
+                          foregroundColor: AppColors.error,
+                          side:
+                              const BorderSide(color: AppColors.error),
+                          padding:
+                              const EdgeInsets.symmetric(vertical: 14),
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(12),
+                          ),
+                        ),
+                        child: const Text('Kustuta'),
+                      ),
+                    ),
+                  if (!category.isDefault) const SizedBox(width: 12),
+                  Expanded(
+                    child: _SheetSaveButton(
+                      label: 'Salvesta',
+                      onTap: () {
+                        if (!category.isDefault) {
+                          notifier.updateCategoryName(
+                              index, nameCtrl.text);
+                        }
+                        notifier.updateCategoryAllocationPercent(
+                            index, localPercent);
+                        Navigator.pop(context);
+                      },
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _CategoryRow extends StatelessWidget {
+  final BudgetCategory category;
+  final double accentOpacity;
+  final VoidCallback onEdit;
+
+  const _CategoryRow({
+    required this.category,
+    required this.accentOpacity,
+    required this.onEdit,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+      child: Row(
+        children: [
+          Container(
+            width: 40,
+            height: 40,
+            decoration: BoxDecoration(
+              color: AppColors.primarySoft,
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: Icon(
+              _iconForCategory(category.name),
+              color: AppColors.primary.withValues(alpha: accentOpacity),
+              size: 20,
+            ),
+          ),
+          const SizedBox(width: 14),
+          Expanded(
+            child: Text(
+              category.name,
+              style: const TextStyle(
+                color: AppColors.textPrimary,
+                fontSize: 15,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+          Text(
+            '${category.allocationPercent.toStringAsFixed(0)}%',
+            style: const TextStyle(
+              color: AppColors.textPrimary,
+              fontSize: 14,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          const SizedBox(width: 12),
+          GestureDetector(
+            onTap: onEdit,
+            child: const Icon(
+              Icons.edit_outlined,
+              color: AppColors.textSecondary,
+              size: 18,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  IconData _iconForCategory(String name) {
+    final l = name.toLowerCase();
+    if (l.contains('toit') || l.contains('söök') || l.contains('restoran')) {
+      return Icons.restaurant;
+    }
+    if (l.contains('transport') ||
+        l.contains('auto') ||
+        l.contains('kütus') ||
+        l.contains('buss')) {
+      return Icons.directions_car;
+    }
+    if (l.contains('üür') ||
+        l.contains('kodu') ||
+        l.contains('maja') ||
+        l.contains('kommunaal')) {
+      return Icons.home;
+    }
+    if (l.contains('meelelahutus') ||
+        l.contains('hobi') ||
+        l.contains('vaba')) {
+      return Icons.confirmation_number;
+    }
+    if (l.contains('tervis') || l.contains('arst') || l.contains('apteek')) {
+      return Icons.favorite_border;
+    }
+    if (l.contains('riided') || l.contains('mood') || l.contains('rõivad')) {
+      return Icons.checkroom;
+    }
+    if (l.contains('haridus') || l.contains('kool') || l.contains('kursus')) {
+      return Icons.school;
+    }
+    if (l.contains('säästud') ||
+        l.contains('hoiused') ||
+        l.contains('investee')) {
+      return Icons.savings;
+    }
+    return Icons.label_outline;
+  }
+}
+
+class _AllocationBar extends StatelessWidget {
+  final List<BudgetCategory> categories;
+
+  const _AllocationBar({required this.categories});
+
+  static const _opacities = [1.0, 0.65, 0.45, 0.28, 0.15];
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(4),
+        child: SizedBox(
+          height: 6,
+          child: Row(
+            children: categories.asMap().entries.map((e) {
+              final pct = e.value.allocationPercent / 100;
+              if (pct <= 0) return const SizedBox.shrink();
+              return Flexible(
+                flex: (pct * 1000).round(),
+                child: Container(
+                  color: AppColors.primary
+                      .withValues(alpha: _opacities[e.key % _opacities.length]),
+                ),
+              );
+            }).toList(),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ── Add category button ────────────────────────────────────────────────────────
+
+class _AddCategoryButton extends StatelessWidget {
+  final SettingsNotifier notifier;
+
+  const _AddCategoryButton({required this.notifier});
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () => _showAddSheet(context),
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.symmetric(vertical: 16),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(
+            color: AppColors.primary.withValues(alpha: 0.3),
+            width: 1.5,
+            strokeAlign: BorderSide.strokeAlignInside,
+          ),
+        ),
+        child: const Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(Icons.add_circle_outline,
+                color: AppColors.primary, size: 20),
+            SizedBox(width: 8),
+            Text(
+              'Lisa uus kategooria',
+              style: TextStyle(
+                color: AppColors.primary,
+                fontSize: 14,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _showAddSheet(BuildContext context) {
+    final ctrl = TextEditingController();
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (_) => _BottomSheetContainer(
+        title: 'Uus kategooria',
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              'Kategooria nimi',
+              style:
+                  TextStyle(color: AppColors.textSecondary, fontSize: 12),
+            ),
+            const SizedBox(height: 6),
+            TextField(
+              controller: ctrl,
+              autofocus: true,
+              textCapitalization: TextCapitalization.sentences,
+              style: const TextStyle(
+                color: AppColors.textPrimary,
+                fontSize: 15,
+                fontWeight: FontWeight.w600,
+              ),
+              decoration: InputDecoration(
+                filled: true,
+                fillColor: AppColors.inputFill,
+                hintText: 'nt. Spordiklubi',
+                hintStyle: const TextStyle(color: AppColors.textMuted),
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(10),
+                  borderSide: BorderSide.none,
+                ),
+                contentPadding: const EdgeInsets.symmetric(
+                    horizontal: 14, vertical: 12),
+              ),
+            ),
+            const SizedBox(height: 24),
+            _SheetSaveButton(
+              label: 'Lisa kategooria',
+              onTap: () {
+                notifier.addCategory(ctrl.text);
+                Navigator.pop(context);
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ── Notifications card ────────────────────────────────────────────────────────
+
+class _NotificationsCard extends StatelessWidget {
+  final SettingsState state;
+  final SettingsNotifier notifier;
+
+  const _NotificationsCard(
+      {required this.state, required this.notifier});
+
+  @override
+  Widget build(BuildContext context) {
+    return _Card(
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+          child: Row(
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: const [
+                    Text(
+                      'Märguanded',
+                      style: TextStyle(
+                        color: AppColors.textPrimary,
+                        fontSize: 15,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    SizedBox(height: 3),
+                    Text(
+                      'Saate lubada või keelata meeldetuletus-stiilis teavitused',
+                      style: TextStyle(
+                        color: AppColors.textSecondary,
+                        fontSize: 12,
+                        height: 1.4,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 12),
+              Switch(
+                value: state.notificationsEnabled,
+                onChanged: notifier.toggleNotifications,
+                activeThumbColor: Colors.white,
+                activeTrackColor: AppColors.primary,
+                inactiveThumbColor: Colors.white,
+                inactiveTrackColor: AppColors.textMuted,
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// ── Data security card ────────────────────────────────────────────────────────
+
+class _DataSecurityCard extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: AppColors.primarySoft.withValues(alpha: 0.6),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(
+          color: AppColors.primary.withValues(alpha: 0.12),
+        ),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Container(
+              padding: const EdgeInsets.all(8),
+              decoration: BoxDecoration(
+                color: AppColors.primary.withValues(alpha: 0.12),
+                borderRadius: BorderRadius.circular(10),
+              ),
+              child: const Icon(
+                Icons.security,
+                color: AppColors.primary,
+                size: 20,
+              ),
+            ),
+            const SizedBox(width: 14),
+            const Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Andmete turvalisus',
+                    style: TextStyle(
+                      color: AppColors.textPrimary,
+                      fontSize: 14,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                  SizedBox(height: 4),
+                  Text(
+                    'Teie andmeid hoitakse turvaliselt ainult teie seadmes. '
+                    'Rakendus ei saada teie finantsandmeid välis-serveritesse.',
+                    style: TextStyle(
+                      color: AppColors.textSecondary,
+                      fontSize: 12,
+                      height: 1.45,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ── No profile banner ─────────────────────────────────────────────────────────
+
+class _NoProfileBanner extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: AppColors.warningBg,
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(
+            color: AppColors.warning.withValues(alpha: 0.3)),
+      ),
+      child: const Row(
+        children: [
+          Icon(Icons.info_outline, color: AppColors.warning, size: 20),
+          SizedBox(width: 12),
+          Expanded(
+            child: Text(
+              'Eelarve profiil puudub. Seadistage rakendus esmalt.',
+              style: TextStyle(
+                color: AppColors.warning,
+                fontSize: 13,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ── Save button (pinned above nav) ────────────────────────────────────────────
+
+class _SaveButton extends StatelessWidget {
+  final SettingsState state;
+  final SettingsNotifier notifier;
+
+  const _SaveButton({required this.state, required this.notifier});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 8, 20, 16),
+      child: SizedBox(
+        width: double.infinity,
+        child: FilledButton(
+          onPressed:
+              state.isSaving || !state.isFormValid ? null : notifier.saveChanges,
+          style: FilledButton.styleFrom(
+            backgroundColor: AppColors.primary,
+            disabledBackgroundColor: AppColors.primary.withValues(alpha: 0.4),
+            padding: const EdgeInsets.symmetric(vertical: 18),
+            shape: const StadiumBorder(),
+            elevation: 0,
+          ),
+          child: state.isSaving
+              ? const SizedBox(
+                  height: 18,
+                  width: 18,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2,
+                    color: Colors.white,
+                  ),
+                )
+              : const Text(
+                  'Salvesta muudatused',
+                  style: TextStyle(
+                    fontSize: 15,
+                    fontWeight: FontWeight.w700,
+                    color: Colors.white,
+                  ),
+                ),
+        ),
+      ),
+    );
+  }
+}
+
+// ── Shared primitives ─────────────────────────────────────────────────────────
+
+class _Card extends StatelessWidget {
+  final List<Widget> children;
+
+  const _Card({required this.children});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.03),
+            blurRadius: 8,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: children,
+        ),
+      ),
+    );
+  }
+}
+
+class _TappableRow extends StatelessWidget {
+  final String label;
+  final String subtitle;
+  final String value;
+  final VoidCallback onTap;
+
+  const _TappableRow({
+    required this.label,
+    required this.subtitle,
+    required this.value,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+        child: Row(
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    label,
+                    style: const TextStyle(
+                      color: AppColors.textPrimary,
+                      fontSize: 15,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    subtitle,
+                    style: const TextStyle(
+                      color: AppColors.textSecondary,
+                      fontSize: 12,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Text(
+              value,
+              style: const TextStyle(
+                color: AppColors.primary,
+                fontSize: 14,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+            const SizedBox(width: 4),
+            const Icon(Icons.chevron_right,
+                color: AppColors.textSecondary, size: 18),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _RowDivider extends StatelessWidget {
+  const _RowDivider();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Divider(
+      height: 1,
+      thickness: 1,
+      color: Color(0xFFF0F3F7),
+      indent: 16,
+      endIndent: 16,
+    );
+  }
+}
+
+class _BottomSheetContainer extends StatelessWidget {
+  final String title;
+  final Widget child;
+
+  const _BottomSheetContainer({required this.title, required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.all(12),
+      padding: EdgeInsets.fromLTRB(
+        20,
+        20,
+        20,
+        20 + MediaQuery.of(context).viewInsets.bottom,
+      ),
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: const TextStyle(
+              color: AppColors.textPrimary,
+              fontSize: 17,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          const SizedBox(height: 16),
+          child,
+        ],
+      ),
+    );
+  }
+}
+
+class _AmountField extends StatelessWidget {
+  final TextEditingController controller;
+
+  const _AmountField({required this.controller});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        const Text(
+          '€',
+          style: TextStyle(
+            color: AppColors.textSecondary,
+            fontSize: 20,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        const SizedBox(width: 8),
+        Expanded(
+          child: TextField(
+            controller: controller,
+            autofocus: true,
+            keyboardType:
+                const TextInputType.numberWithOptions(decimal: true),
+            inputFormatters: [
+              FilteringTextInputFormatter.allow(RegExp(r'[\d.,]')),
+            ],
+            style: const TextStyle(
+              color: AppColors.textPrimary,
+              fontSize: 22,
+              fontWeight: FontWeight.w700,
+            ),
+            decoration: const InputDecoration(
+              isDense: true,
+              border: InputBorder.none,
+              hintText: '0,00',
+              hintStyle: TextStyle(
+                color: AppColors.textMuted,
+                fontWeight: FontWeight.w400,
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _SheetSaveButton extends StatelessWidget {
+  final String label;
+  final VoidCallback onTap;
+
+  const _SheetSaveButton({required this.label, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      child: FilledButton(
+        onPressed: onTap,
+        style: FilledButton.styleFrom(
+          backgroundColor: AppColors.primary,
+          padding: const EdgeInsets.symmetric(vertical: 15),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12),
+          ),
+        ),
+        child: Text(
+          label,
+          style: const TextStyle(
+            fontSize: 15,
+            fontWeight: FontWeight.w600,
+            color: Colors.white,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _CurrencyOption extends StatelessWidget {
+  final String code;
+  final String name;
+  final String symbol;
+  final bool isSelected;
+  final VoidCallback onTap;
+
+  const _CurrencyOption({
+    required this.code,
+    required this.name,
+    required this.symbol,
+    required this.isSelected,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(12),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 14, horizontal: 4),
+        child: Row(
+          children: [
+            Container(
+              width: 36,
+              height: 36,
+              decoration: BoxDecoration(
+                color: AppColors.primarySoft,
+                borderRadius: BorderRadius.circular(8),
+              ),
+              alignment: Alignment.center,
+              child: Text(
+                symbol,
+                style: const TextStyle(
+                  color: AppColors.primary,
+                  fontSize: 16,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+            ),
+            const SizedBox(width: 14),
+            Expanded(
+              child: Text(
+                '$name ($code)',
+                style: const TextStyle(
+                  color: AppColors.textPrimary,
+                  fontSize: 15,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+            ),
+            if (isSelected)
+              const Icon(Icons.check_circle,
+                  color: AppColors.primary, size: 20),
+          ],
         ),
       ),
     );

--- a/lib/features/setup/data/datasources/setup_local_data_source.dart
+++ b/lib/features/setup/data/datasources/setup_local_data_source.dart
@@ -1,5 +1,3 @@
-import 'package:sqflite/sqflite.dart';
-
 import '../../../../core/database/app_database.dart';
 import '../../domain/models/budget_category.dart';
 import '../../domain/models/budget_profile.dart';
@@ -76,4 +74,117 @@ class SetupLocalDataSource {
       await txn.delete('budget_profiles');
     });
   }
+
+  Future<void> updateBudgetProfile(BudgetProfile profile) async {
+    assert(profile.id != null, 'Cannot update a profile without an id');
+    final db = await appDatabase.database;
+
+    await db.transaction((txn) async {
+      await txn.update(
+        'budget_profiles',
+        {
+          'monthly_income': profile.monthlyIncome,
+          'monthly_fixed_expenses': profile.monthlyFixedExpenses,
+          'safety_buffer': profile.safetyBuffer,
+          'distributable_amount': profile.distributableAmount,
+          'currency_code': profile.currencyCode,
+          'updated_at': profile.updatedAt.toIso8601String(),
+        },
+        where: 'id = ?',
+        whereArgs: [profile.id],
+      );
+
+      final categoryRows = await txn.query(
+        'budget_categories',
+        columns: ['id', 'allocation_percent'],
+        where: 'budget_profile_id = ?',
+        whereArgs: [profile.id],
+      );
+
+      final now = DateTime.now().toIso8601String();
+
+      for (final row in categoryRows) {
+        final allocationPercent = (row['allocation_percent'] as num).toDouble();
+        final newPlannedAmount =
+            _roundTo2(profile.distributableAmount * (allocationPercent / 100));
+
+        await txn.update(
+          'budget_categories',
+          {'planned_amount': newPlannedAmount, 'updated_at': now},
+          where: 'id = ?',
+          whereArgs: [row['id']],
+        );
+      }
+    });
+  }
+
+  /// Syncs categories for a profile: updates existing (by id), inserts new
+  /// (no id), deletes removed ones. Recalculates plannedAmount from
+  /// [distributableAmount] × allocationPercent. Preserves category IDs so
+  /// existing expenses remain linked.
+  Future<void> syncCategories({
+    required int profileId,
+    required double distributableAmount,
+    required List<BudgetCategory> categories,
+  }) async {
+    final db = await appDatabase.database;
+
+    await db.transaction((txn) async {
+      final existing = await txn.query(
+        'budget_categories',
+        columns: ['id'],
+        where: 'budget_profile_id = ?',
+        whereArgs: [profileId],
+      );
+      final existingIds = existing.map((r) => r['id'] as int).toSet();
+      final keepIds =
+          categories.where((c) => c.id != null).map((c) => c.id!).toSet();
+
+      // Delete categories removed by user
+      for (final id in existingIds.difference(keepIds)) {
+        await txn.delete(
+          'budget_categories',
+          where: 'id = ?',
+          whereArgs: [id],
+        );
+      }
+
+      final now = DateTime.now().toIso8601String();
+
+      for (int i = 0; i < categories.length; i++) {
+        final cat = categories[i];
+        final plannedAmount =
+            _roundTo2(distributableAmount * (cat.allocationPercent / 100));
+
+        if (cat.id != null && existingIds.contains(cat.id)) {
+          await txn.update(
+            'budget_categories',
+            {
+              'name': cat.name,
+              'allocation_percent': cat.allocationPercent,
+              'planned_amount': plannedAmount,
+              'sort_order': i,
+              'updated_at': now,
+            },
+            where: 'id = ?',
+            whereArgs: [cat.id],
+          );
+        } else {
+          await txn.insert('budget_categories', {
+            'budget_profile_id': profileId,
+            'name': cat.name,
+            'allocation_percent': cat.allocationPercent,
+            'planned_amount': plannedAmount,
+            'sort_order': i,
+            'is_default': cat.isDefault ? 1 : 0,
+            'created_at': now,
+            'updated_at': now,
+          });
+        }
+      }
+    });
+  }
+
+  double _roundTo2(double value) =>
+      double.parse(value.toStringAsFixed(2));
 }

--- a/lib/features/setup/data/repositories/setup_repository.dart
+++ b/lib/features/setup/data/repositories/setup_repository.dart
@@ -14,4 +14,12 @@ abstract class SetupRepository {
   Future<bool> hasCompletedSetup();
 
   Future<void> clearSetup();
+
+  Future<void> updateBudgetProfile(BudgetProfile profile);
+
+  Future<void> syncCategories({
+    required int profileId,
+    required double distributableAmount,
+    required List<BudgetCategory> categories,
+  });
 }

--- a/lib/features/setup/data/repositories/setup_repository_impl.dart
+++ b/lib/features/setup/data/repositories/setup_repository_impl.dart
@@ -40,4 +40,22 @@ class SetupRepositoryImpl implements SetupRepository {
   Future<void> clearSetup() {
     return localDataSource.clearSetup();
   }
+
+  @override
+  Future<void> updateBudgetProfile(BudgetProfile profile) {
+    return localDataSource.updateBudgetProfile(profile);
+  }
+
+  @override
+  Future<void> syncCategories({
+    required int profileId,
+    required double distributableAmount,
+    required List<BudgetCategory> categories,
+  }) {
+    return localDataSource.syncCategories(
+      profileId: profileId,
+      distributableAmount: distributableAmount,
+      categories: categories,
+    );
+  }
 }


### PR DESCRIPTION
Closes #15 

Implemented the settings feature so it actually works end to end instead of being just a placeholder.

What’s included:

settings screen UI
editable safety buffer
currency selection
notifications toggle with persistence
local data/info section
budget profile update flow
refresh of summary/dependent views after changes
category/budget editing entry integrated into settings

Also made sure updated values are saved properly and reflected across the app without needing to rerun setup.