### PR TITLE
add remote insight card with moodbased gif support

### DIFF
--- a/lib/features/grocery/presentation/grocery_overview_screen.dart
+++ b/lib/features/grocery/presentation/grocery_overview_screen.dart
@@ -35,7 +35,6 @@ class GroceryOverviewScreen extends ConsumerWidget {
   }
 }
 
-// ── Main content ─────────────────────────────────────────────────────────────
 
 class _OverviewBody extends ConsumerWidget {
   const _OverviewBody({required this.state});
@@ -69,7 +68,6 @@ class _OverviewBody extends ConsumerWidget {
   }
 }
 
-// ── Screen header ─────────────────────────────────────────────────────────────
 
 class _ScreenHeader extends StatelessWidget {
   const _ScreenHeader({required this.monthLabel});
@@ -100,7 +98,6 @@ class _ScreenHeader extends StatelessWidget {
   }
 }
 
-// ── Month summary row (totals across all categories) ─────────────────────────
 
 class _MonthSummaryRow extends StatelessWidget {
   const _MonthSummaryRow({required this.overviews});
@@ -214,7 +211,6 @@ class _Divider extends StatelessWidget {
   }
 }
 
-// ── Category card ─────────────────────────────────────────────────────────────
 
 class _CategoryCard extends StatelessWidget {
   const _CategoryCard({required this.overview});
@@ -236,7 +232,6 @@ class _CategoryCard extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          // ── Header row ──────────────────────────────────────────────────
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
@@ -252,7 +247,6 @@ class _CategoryCard extends StatelessWidget {
           ),
           const SizedBox(height: 14),
 
-          // ── Amounts row ──────────────────────────────────────────────────
           Row(
             children: [
               Expanded(
@@ -286,7 +280,6 @@ class _CategoryCard extends StatelessWidget {
           ),
           const SizedBox(height: 14),
 
-          // ── Progress bar ─────────────────────────────────────────────────
           ClipRRect(
             borderRadius: BorderRadius.circular(4),
             child: LinearProgressIndicator(
@@ -297,14 +290,12 @@ class _CategoryCard extends StatelessWidget {
             ),
           ),
 
-          // ── Daily suggestion ─────────────────────────────────────────────
           if (overview.suggestedDailyAmount != null &&
               overview.remainingDays > 0) ...[
             const SizedBox(height: 12),
             _DailySuggestionLine(overview: overview),
           ],
 
-          // ── Overspent note ───────────────────────────────────────────────
           if (overview.isOverBudget) ...[
             const SizedBox(height: 12),
             _OverspentLine(amount: overview.overspentAmount),
@@ -405,7 +396,6 @@ class _OverspentLine extends StatelessWidget {
   }
 }
 
-// ── Status badge ──────────────────────────────────────────────────────────────
 
 class _StatusBadge extends StatelessWidget {
   const _StatusBadge({required this.status, required this.colors});
@@ -453,7 +443,6 @@ class _StatusBadge extends StatelessWidget {
   }
 }
 
-// ── Empty / error states ──────────────────────────────────────────────────────
 
 class _NotConfiguredState extends StatelessWidget {
   const _NotConfiguredState();
@@ -547,9 +536,7 @@ class _EmptyLayout extends StatelessWidget {
   }
 }
 
-// ── Helpers ───────────────────────────────────────────────────────────────────
 
-/// Formats a non-negative amount as "X,XX €".
 String _fmt(double amount) =>
     '${amount.abs().toStringAsFixed(2).replaceAll('.', ',')} €';
 

--- a/lib/features/home/data/datasources/remote_insight_data_source.dart
+++ b/lib/features/home/data/datasources/remote_insight_data_source.dart
@@ -1,0 +1,32 @@
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
+
+import '../../domain/entities/budget_mood.dart';
+import '../dto/remote_insight_dto.dart';
+
+abstract interface class RemoteInsightDataSource {
+  Future<RemoteInsightDto> fetchInsight(BudgetMood mood);
+}
+
+class DioRemoteInsightDataSource implements RemoteInsightDataSource {
+  const DioRemoteInsightDataSource(this._dio);
+
+  final Dio _dio;
+
+  static const _urls = {
+    BudgetMood.good:
+        'https://gist.githubusercontent.com/rogerpurtsak/4382542916c7f25d005312792e35898d/raw',
+    BudgetMood.medium:
+        'https://gist.githubusercontent.com/rogerpurtsak/1377f8d620ec67cdfcab08cc83f0b23e/raw',
+    BudgetMood.critical:
+        'https://gist.githubusercontent.com/rogerpurtsak/55afcd265b7809eaad42deed43f7fb42/raw',
+  };
+
+  @override
+  Future<RemoteInsightDto> fetchInsight(BudgetMood mood) async {
+    final response = await _dio.get<String>(_urls[mood]!);
+    final json = jsonDecode(response.data!) as Map<String, dynamic>;
+    return RemoteInsightDto.fromJson(json);
+  }
+}

--- a/lib/features/home/data/dto/remote_insight_dto.dart
+++ b/lib/features/home/data/dto/remote_insight_dto.dart
@@ -1,0 +1,47 @@
+import '../../domain/entities/budget_mood.dart';
+import '../../domain/entities/remote_insight.dart';
+
+class RemoteInsightDto {
+  const RemoteInsightDto({
+    required this.title,
+    required this.message,
+    required this.mood,
+    this.gifUrl,
+  });
+
+  final String title;
+  final String message;
+  final String mood;
+  final String? gifUrl;
+
+  factory RemoteInsightDto.fromJson(Map<String, dynamic> json) {
+    return RemoteInsightDto(
+      title: json['title'] as String,
+      message: json['message'] as String,
+      mood: json['mood'] as String,
+      gifUrl: json['gifUrl'] as String?,
+    );
+  }
+
+  RemoteInsight toDomain() {
+    return RemoteInsight(
+      title: title,
+      message: message,
+      mood: _parseMood(mood),
+      gifUrl: gifUrl,
+    );
+  }
+
+  static BudgetMood _parseMood(String raw) {
+    switch (raw) {
+      case 'good':
+        return BudgetMood.good;
+      case 'medium':
+        return BudgetMood.medium;
+      case 'critical':
+        return BudgetMood.critical;
+      default:
+        return BudgetMood.good;
+    }
+  }
+}

--- a/lib/features/home/data/repositories/remote_insight_repository_impl.dart
+++ b/lib/features/home/data/repositories/remote_insight_repository_impl.dart
@@ -1,0 +1,16 @@
+import '../../domain/entities/budget_mood.dart';
+import '../../domain/entities/remote_insight.dart';
+import '../../domain/repositories/remote_insight_repository.dart';
+import '../datasources/remote_insight_data_source.dart';
+
+class RemoteInsightRepositoryImpl implements RemoteInsightRepository {
+  const RemoteInsightRepositoryImpl(this._dataSource);
+
+  final RemoteInsightDataSource _dataSource;
+
+  @override
+  Future<RemoteInsight> fetchInsight(BudgetMood mood) async {
+    final dto = await _dataSource.fetchInsight(mood);
+    return dto.toDomain();
+  }
+}

--- a/lib/features/home/domain/entities/budget_mood.dart
+++ b/lib/features/home/domain/entities/budget_mood.dart
@@ -1,0 +1,5 @@
+enum BudgetMood {
+  good,
+  medium,
+  critical,
+}

--- a/lib/features/home/domain/entities/remote_insight.dart
+++ b/lib/features/home/domain/entities/remote_insight.dart
@@ -1,0 +1,15 @@
+import 'budget_mood.dart';
+
+class RemoteInsight {
+  const RemoteInsight({
+    required this.title,
+    required this.message,
+    required this.mood,
+    this.gifUrl,
+  });
+
+  final String title;
+  final String message;
+  final BudgetMood mood;
+  final String? gifUrl;
+}

--- a/lib/features/home/domain/repositories/remote_insight_repository.dart
+++ b/lib/features/home/domain/repositories/remote_insight_repository.dart
@@ -1,0 +1,6 @@
+import '../entities/budget_mood.dart';
+import '../entities/remote_insight.dart';
+
+abstract interface class RemoteInsightRepository {
+  Future<RemoteInsight> fetchInsight(BudgetMood mood);
+}

--- a/lib/features/home/domain/services/budget_mood_evaluator.dart
+++ b/lib/features/home/domain/services/budget_mood_evaluator.dart
@@ -1,0 +1,18 @@
+import '../entities/budget_mood.dart';
+import '../entities/category_summary.dart';
+
+class BudgetMoodEvaluator {
+
+  BudgetMood evaluate(List<CategorySummary> categories) {
+
+    if (categories.isEmpty) return BudgetMood.good;
+
+    final hasOverBudget = categories.any((c) => c.isOverBudget);
+    if (hasOverBudget) return BudgetMood.critical;
+
+    final hasNearLimit = categories.any((c) => c.isNearLimit);
+    if (hasNearLimit) return BudgetMood.medium;
+
+    return BudgetMood.good;
+  }
+}

--- a/lib/features/home/domain/services/home_summary_calculator.dart
+++ b/lib/features/home/domain/services/home_summary_calculator.dart
@@ -1,3 +1,6 @@
+// ignore: avoid_print
+import 'dart:developer' as dev;
+
 import '../entities/category_summary.dart';
 import '../entities/dashboard_source_models.dart';
 import '../entities/home_insight.dart';
@@ -14,6 +17,7 @@ class HomeSummaryCalculator {
     final spentByCategory = <String, double>{};
 
     for (final expense in expenses) {
+      dev.log('EXPENSE: id=${expense.id} categoryId="${expense.budgetCategoryId}" amount=${expense.amount}');
       spentByCategory.update(
         expense.budgetCategoryId,
         (value) => value + expense.amount,
@@ -21,10 +25,13 @@ class HomeSummaryCalculator {
       );
     }
 
+    dev.log('spentByCategory keys: ${spentByCategory.keys.toList()}');
+
     final categorySummaries = categories
         .map(
           (category) {
             final spentAmount = spentByCategory[category.id] ?? 0;
+            dev.log('CATEGORY: id="${category.id}" name="${category.name}" spent=$spentAmount');
             final plannedAmount = category.plannedAmount;
             final remainingAmount = plannedAmount - spentAmount;
             final usagePercent = plannedAmount <= 0

--- a/lib/features/home/presentation/home_screen.dart
+++ b/lib/features/home/presentation/home_screen.dart
@@ -5,11 +5,14 @@ import 'package:go_router/go_router.dart';
 import 'providers/home_summary_provider.dart';
 import 'widgets/dashboard_currency.dart';
 import 'widgets/dashboard_header.dart';
-import 'widgets/home_category_highlight_card.dart';
+import 'widgets/home_categories_section.dart';
 import 'widgets/home_empty_state.dart';
 import 'widgets/home_insight_card.dart';
 import 'widgets/home_primary_summary_card.dart';
 import 'widgets/home_stat_card.dart';
+import 'providers/remote_insight_provider.dart';
+import 'widgets/remote_insight_card.dart';
+
 
 class HomeScreen extends ConsumerWidget {
   const HomeScreen({super.key});
@@ -87,14 +90,20 @@ class HomeScreen extends ConsumerWidget {
                             ),
                           ],
                         ),
-                        if (summary.highlightedCategory != null) ...[
+                        if (summary.categorySummaries.isNotEmpty) ...[
                           const SizedBox(height: 12),
-                          HomeCategoryHighlightCard(
-                            category: summary.highlightedCategory!,
+                          HomeCategoriesSection(
+                            categories: summary.categorySummaries,
                           ),
                         ],
                         const SizedBox(height: 12),
-                        HomeInsightCard(insight: summary.insight),
+                        ref.watch(remoteInsightProvider).when(
+                          loading: () => HomeInsightCard(insight: summary.insight),
+                          error: (e, _) => Text('REMOTE VIGA: $e'),
+                          data: (remote) => remote != null
+                              ? RemoteInsightCard(insight: remote)
+                              : HomeInsightCard(insight: summary.insight),
+                        ),
                       ],
                     ),
                   ),

--- a/lib/features/home/presentation/providers/remote_insight_provider.dart
+++ b/lib/features/home/presentation/providers/remote_insight_provider.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../core/network/dio_provider.dart';
+import '../../data/datasources/remote_insight_data_source.dart';
+import '../../data/repositories/remote_insight_repository_impl.dart';
+import '../../domain/entities/remote_insight.dart';
+import '../../domain/repositories/remote_insight_repository.dart';
+import '../../domain/services/budget_mood_evaluator.dart';
+import 'home_summary_provider.dart';
+
+final budgetMoodEvaluatorProvider = Provider<BudgetMoodEvaluator>(
+  (_) => BudgetMoodEvaluator(),
+);
+
+final remoteInsightDataSourceProvider = Provider<RemoteInsightDataSource>(
+  (ref) => DioRemoteInsightDataSource(ref.read(dioProvider)),
+);
+
+final remoteInsightRepositoryProvider = Provider<RemoteInsightRepository>((ref) {
+  return RemoteInsightRepositoryImpl(
+    ref.read(remoteInsightDataSourceProvider),
+  );
+});
+
+
+final remoteInsightProvider = FutureProvider<RemoteInsight?>((ref) async {
+  final summaryAsync = ref.watch(homeSummaryProvider);
+  final summary = summaryAsync.value?.summary;
+  if (summary == null) return null;
+
+  final mood = ref.read(budgetMoodEvaluatorProvider)
+      .evaluate(summary.categorySummaries);
+
+  final repository = ref.read(remoteInsightRepositoryProvider);
+  return repository.fetchInsight(mood);
+});

--- a/lib/features/home/presentation/widgets/home_categories_section.dart
+++ b/lib/features/home/presentation/widgets/home_categories_section.dart
@@ -1,0 +1,139 @@
+import 'package:flutter/material.dart';
+
+import '../../domain/entities/category_summary.dart';
+import 'dashboard_currency.dart';
+
+/// Shows all budget categories in a compact stacked card on the home screen.
+class HomeCategoriesSection extends StatelessWidget {
+  const HomeCategoriesSection({
+    super.key,
+    required this.categories,
+  });
+
+  final List<CategorySummary> categories;
+
+  @override
+  Widget build(BuildContext context) {
+    if (categories.isEmpty) return const SizedBox.shrink();
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Kategooriad',
+          style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: const Color(0xFF6B7B79),
+                fontWeight: FontWeight.w600,
+                letterSpacing: 0.3,
+              ),
+        ),
+        const SizedBox(height: 8),
+        Container(
+          decoration: BoxDecoration(
+            color: const Color(0xFFF3F7FF),
+            borderRadius: BorderRadius.circular(20),
+          ),
+          child: Column(
+            children: [
+              for (int i = 0; i < categories.length; i++) ...[
+                if (i > 0)
+                  const Divider(
+                    height: 1,
+                    thickness: 1,
+                    color: Color(0xFFE8EEF3),
+                    indent: 16,
+                    endIndent: 16,
+                  ),
+                _CategoryRow(category: categories[i]),
+              ],
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _CategoryRow extends StatelessWidget {
+  const _CategoryRow({required this.category});
+
+  final CategorySummary category;
+
+  @override
+  Widget build(BuildContext context) {
+    final progress = category.plannedAmount <= 0
+        ? 0.0
+        : (category.spentAmount / category.plannedAmount).clamp(0.0, 1.0);
+
+    final Color statusColor;
+    if (category.isOverBudget) {
+      statusColor = const Color(0xFFBA1A1A);
+    } else if (category.isNearLimit) {
+      statusColor = const Color(0xFFB25D36);
+    } else {
+      statusColor = const Color(0xFF006763);
+    }
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  category.name,
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        fontWeight: FontWeight.w700,
+                        color: const Color(0xFF021C36),
+                      ),
+                ),
+              ),
+              Text(
+                formatCurrency(category.remainingAmount),
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      fontWeight: FontWeight.w700,
+                      color: statusColor,
+                    ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 6),
+          Row(
+            children: [
+              Expanded(
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(999),
+                  child: LinearProgressIndicator(
+                    value: progress,
+                    minHeight: 5,
+                    backgroundColor: const Color(0xFFE3EAE9),
+                    valueColor: AlwaysStoppedAnimation(statusColor),
+                  ),
+                ),
+              ),
+              const SizedBox(width: 10),
+              Text(
+                '${(category.usagePercent * 100).toStringAsFixed(0)}%',
+                style: TextStyle(
+                  color: statusColor,
+                  fontSize: 11,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 3),
+          Text(
+            '${formatCurrency(category.spentAmount)} / ${formatCurrency(category.plannedAmount)}',
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: const Color(0xFF6B7B79),
+                  fontSize: 11,
+                ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/home/presentation/widgets/remote_insight_card.dart
+++ b/lib/features/home/presentation/widgets/remote_insight_card.dart
@@ -1,0 +1,137 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+
+import '../../domain/entities/budget_mood.dart';
+import '../../domain/entities/remote_insight.dart';
+
+class RemoteInsightCard extends StatelessWidget {
+  const RemoteInsightCard({super.key, required this.insight});
+
+  final RemoteInsight insight;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = _resolveColors(insight.mood);
+
+    return Container(
+      padding: const EdgeInsets.all(18),
+      decoration: BoxDecoration(
+        color: colors.background,
+        borderRadius: BorderRadius.circular(24),
+        border: Border.all(color: colors.border),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Container(
+                padding: const EdgeInsets.all(10),
+                decoration: BoxDecoration(
+                  color: colors.iconBackground,
+                  borderRadius: BorderRadius.circular(16),
+                ),
+                child: Icon(colors.icon, color: colors.iconColor),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      insight.title,
+                      style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                            color: colors.titleColor,
+                            fontWeight: FontWeight.w800,
+                          ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      insight.message,
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                            color: colors.messageColor,
+                          ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          if (insight.gifUrl != null) ...[
+            const SizedBox(height: 12),
+            ClipRRect(
+              borderRadius: BorderRadius.circular(12),
+              child: CachedNetworkImage(
+                imageUrl: insight.gifUrl!,
+                height: 160,
+                width: double.infinity,
+                fit: BoxFit.cover,
+                placeholder: (_, _) => const SizedBox(
+                  height: 160,
+                  child: Center(child: CircularProgressIndicator()),
+                ),
+                errorWidget: (_, _, _) => const SizedBox.shrink(),
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _InsightColors {
+  const _InsightColors({
+    required this.background,
+    required this.border,
+    required this.iconBackground,
+    required this.iconColor,
+    required this.icon,
+    required this.titleColor,
+    required this.messageColor,
+  });
+
+  final Color background;
+  final Color border;
+  final Color iconBackground;
+  final Color iconColor;
+  final IconData icon;
+  final Color titleColor;
+  final Color messageColor;
+}
+
+_InsightColors _resolveColors(BudgetMood mood) {
+  switch (mood) {
+    case BudgetMood.good:
+      return const _InsightColors(
+        background: Color(0xFFEAF8F5),
+        border: Color(0xFFCBE9E1),
+        iconBackground: Color(0xFFBFE7E3),
+        iconColor: Color(0xFF006763),
+        icon: Icons.sentiment_very_satisfied_outlined,
+        titleColor: Color(0xFF006763),
+        messageColor: Color(0xFF3F5A57),
+      );
+    case BudgetMood.medium:
+      return const _InsightColors(
+        background: Color(0xFFFFF5E8),
+        border: Color(0xFFFFE1B0),
+        iconBackground: Color(0xFFFFE9C7),
+        iconColor: Color(0xFF9A5C00),
+        icon: Icons.sentiment_neutral_outlined,
+        titleColor: Color(0xFF9A5C00),
+        messageColor: Color(0xFF6F5937),
+      );
+    case BudgetMood.critical:
+      return const _InsightColors(
+        background: Color(0xFFFFECE9),
+        border: Color(0xFFF4C7C2),
+        iconBackground: Color(0xFFFFDAD6),
+        iconColor: Color(0xFFBA1A1A),
+        icon: Icons.sentiment_very_dissatisfied_outlined,
+        titleColor: Color(0xFFBA1A1A),
+        messageColor: Color(0xFF6D4B48),
+      );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -73,6 +73,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.5"
+  cached_network_image:
+    dependency: "direct main"
+    description:
+      name: cached_network_image
+      sha256: "7c1183e361e5c8b0a0f21a28401eecdbde252441106a9816400dd4c2b2424916"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.1"
+  cached_network_image_platform_interface:
+    dependency: transitive
+    description:
+      name: cached_network_image_platform_interface
+      sha256: "35814b016e37fbdc91f7ae18c8caf49ba5c88501813f73ce8a07027a395e2829"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.1"
+  cached_network_image_web:
+    dependency: transitive
+    description:
+      name: cached_network_image_web
+      sha256: "980842f4e8e2535b8dbd3d5ca0b1f0ba66bf61d14cc3a17a9b4788a3685ba062"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.1"
   characters:
     dependency: transitive
     description:
@@ -193,11 +217,27 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  fixnum:
+    dependency: transitive
+    description:
+      name: fixnum
+      sha256: b6dc7065e46c974bc7c5f143080a6764ec7a4be6da1285ececdc37be96de53be
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   flutter:
     dependency: "direct main"
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_cache_manager:
+    dependency: transitive
+    description:
+      name: flutter_cache_manager
+      sha256: "400b6592f16a4409a7f2bb929a9a7e38c72cceb8ffb99ee57bbf2cb2cecf8386"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.1"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -416,6 +456,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "9.3.0"
+  octo_image:
+    dependency: transitive
+    description:
+      name: octo_image
+      sha256: "34faa6639a78c7e3cbe79be6f9f96535867e879748ade7d17c9b1ae7536293bd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   package_config:
     dependency: transitive
     description:
@@ -536,6 +584,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.3"
+  rxdart:
+    dependency: transitive
+    description:
+      name: rxdart
+      sha256: "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.28.0"
   shelf:
     dependency: transitive
     description:
@@ -741,6 +797,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  uuid:
+    dependency: transitive
+    description:
+      name: uuid
+      sha256: "1fef9e8e11e2991bb773070d4656b7bd5d850967a2456cfc83cf47925ba79489"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.5.3"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
   path_provider: ^2.1.5
   intl: ^0.20.2
   google_fonts: ^6.2.1
+  cached_network_image: ^3.4.1
   sqflite_common_ffi: ^2.4.0+2
 
 dev_dependencies:


### PR DESCRIPTION
Closes #17 

introduces a mood-based insight card that uses the user’s local category state to decide whether the current budget situation is good, medium, or critical, then shows a matching remote message and optional GIF. The core budgeting logic stays local, while the remote part acts only as an extra layer of feedback.