### PR TITLE
standardize loading, error, and empty states across app

### DIFF
--- a/lib/features/expenses/presentation/add_expense_screen.dart
+++ b/lib/features/expenses/presentation/add_expense_screen.dart
@@ -105,22 +105,20 @@ class _AddExpenseScreenState extends ConsumerState<AddExpenseScreen> {
                   loading: () => const LinearProgressIndicator(
                     color: AppColors.primary,
                   ),
-                  error: (e, s) => const Text(
-                    'Kategooriate laadimine ebaõnnestus.',
-                    style: TextStyle(color: AppColors.error),
+                  error: (e, s) => _InlineNotice(
+                    icon: Icons.error_outline,
+                    message: 'Kategooriate laadimine ebaõnnestus.',
+                    color: AppColors.error,
+                    background: AppColors.errorBg,
                   ),
                   data: (categories) {
                     if (categories.isEmpty) {
-                      return Container(
-                        padding: const EdgeInsets.all(14),
-                        decoration: BoxDecoration(
-                          color: AppColors.inputFill,
-                          borderRadius: BorderRadius.circular(12),
-                        ),
-                        child: const Text(
-                          'Kategooriaid pole. Tee esmalt seadistus.',
-                          style: TextStyle(color: AppColors.textSecondary),
-                        ),
+                      return _InlineNotice(
+                        icon: Icons.tune_outlined,
+                        message:
+                            'Kategooriaid pole. Lisa need esmalt seadistuses.',
+                        color: AppColors.textSecondary,
+                        background: AppColors.inputFill,
                       );
                     }
                     return Wrap(
@@ -495,6 +493,47 @@ class _ReceiptSuggestionCard extends StatelessWidget {
             Icons.add_a_photo_outlined,
             color: AppColors.textMuted,
             size: 22,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _InlineNotice extends StatelessWidget {
+  const _InlineNotice({
+    required this.icon,
+    required this.message,
+    required this.color,
+    required this.background,
+  });
+
+  final IconData icon;
+  final String message;
+  final Color color;
+  final Color background;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+      decoration: BoxDecoration(
+        color: background,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Row(
+        children: [
+          Icon(icon, size: 16, color: color),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Text(
+              message,
+              style: TextStyle(
+                color: color,
+                fontSize: 13,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
           ),
         ],
       ),

--- a/lib/features/grocery/presentation/grocery_overview_screen.dart
+++ b/lib/features/grocery/presentation/grocery_overview_screen.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../../app/theme/app_colors.dart';
-import '../../../app/theme/app_spacing.dart';
+import '../../../shared/widgets/app_state_screen.dart';
 import '../domain/models/category_budget_overview.dart';
 import '../domain/models/category_budget_status.dart';
 import 'providers/grocery_overview_provider.dart';
@@ -18,14 +19,25 @@ class GroceryOverviewScreen extends ConsumerWidget {
       backgroundColor: AppColors.background,
       body: SafeArea(
         child: overviewAsync.when(
-          loading: () => const Center(child: CircularProgressIndicator()),
-          error: (e, _) => _ErrorState(message: e.toString()),
+          loading: () => AppStateScreen.loading(),
+          error: (e, _) => AppStateScreen.error(
+            onRetry: () => ref.invalidate(categoryBudgetOverviewProvider),
+          ),
           data: (state) {
             if (!state.isConfigured) {
-              return const _NotConfiguredState();
+              return AppStateScreen.setupRequired(
+                onSetup: () => context.go('/setup'),
+                body:
+                    'Eelarve ülevaate nägemiseks sisesta esmalt kuine eelarve alus.',
+              );
             }
             if (!state.hasCategories) {
-              return const _NoCategoriesState();
+              return AppStateScreen.setupRequired(
+                onSetup: () => context.go('/setup'),
+                title: 'Kategooriaid pole',
+                body:
+                    'Lisa seadistuses kulukategooriad, et siin ülevaadet näha.',
+              );
             }
             return _OverviewBody(state: state);
           },
@@ -444,97 +456,6 @@ class _StatusBadge extends StatelessWidget {
 }
 
 
-class _NotConfiguredState extends StatelessWidget {
-  const _NotConfiguredState();
-
-  @override
-  Widget build(BuildContext context) {
-    return _EmptyLayout(
-      icon: Icons.tune_outlined,
-      title: 'Seadistus puudub',
-      message: 'Eelarve ülevaate nägemiseks lõpeta esmalt esialgne seadistamine.',
-    );
-  }
-}
-
-class _NoCategoriesState extends StatelessWidget {
-  const _NoCategoriesState();
-
-  @override
-  Widget build(BuildContext context) {
-    return _EmptyLayout(
-      icon: Icons.category_outlined,
-      title: 'Kategooriaid pole',
-      message: 'Lisa seadistuses kulukategooriad, et siin ülevaadet näha.',
-    );
-  }
-}
-
-class _ErrorState extends StatelessWidget {
-  const _ErrorState({required this.message});
-
-  final String message;
-
-  @override
-  Widget build(BuildContext context) {
-    return _EmptyLayout(
-      icon: Icons.error_outline,
-      title: 'Midagi läks valesti',
-      message: message,
-    );
-  }
-}
-
-class _EmptyLayout extends StatelessWidget {
-  const _EmptyLayout({
-    required this.icon,
-    required this.title,
-    required this.message,
-  });
-
-  final IconData icon;
-  final String title;
-  final String message;
-
-  @override
-  Widget build(BuildContext context) {
-    return Center(
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 40),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Container(
-              padding: const EdgeInsets.all(20),
-              decoration: BoxDecoration(
-                color: AppColors.inputFill,
-                shape: BoxShape.circle,
-              ),
-              child: Icon(icon, size: 36, color: AppColors.textSecondary),
-            ),
-            const SizedBox(height: AppSpacing.lg),
-            Text(
-              title,
-              style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                    fontWeight: FontWeight.w700,
-                    color: AppColors.textPrimary,
-                  ),
-              textAlign: TextAlign.center,
-            ),
-            const SizedBox(height: AppSpacing.sm),
-            Text(
-              message,
-              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                    color: AppColors.textSecondary,
-                  ),
-              textAlign: TextAlign.center,
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
 
 
 String _fmt(double amount) =>

--- a/lib/features/home/presentation/home_screen.dart
+++ b/lib/features/home/presentation/home_screen.dart
@@ -2,15 +2,15 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../../../shared/widgets/app_state_screen.dart';
 import 'providers/home_summary_provider.dart';
+import 'providers/remote_insight_provider.dart';
 import 'widgets/dashboard_currency.dart';
 import 'widgets/dashboard_header.dart';
 import 'widgets/home_categories_section.dart';
-import 'widgets/home_empty_state.dart';
 import 'widgets/home_insight_card.dart';
 import 'widgets/home_primary_summary_card.dart';
 import 'widgets/home_stat_card.dart';
-import 'providers/remote_insight_provider.dart';
 import 'widgets/remote_insight_card.dart';
 
 
@@ -24,11 +24,17 @@ class HomeScreen extends ConsumerWidget {
     return Scaffold(
       body: SafeArea(
         child: summaryAsync.when(
-          loading: () => const Center(child: CircularProgressIndicator()),
-          error: (e, _) => Center(child: Text('Viga: $e')),
+          loading: () => AppStateScreen.loading(),
+          error: (e, _) => AppStateScreen.error(
+            onRetry: () => ref.invalidate(homeSummaryProvider),
+          ),
           data: (summaryState) {
             if (!summaryState.isConfigured || summaryState.summary == null) {
-              return HomeEmptyState(onOpenSetup: () => context.go('/setup'));
+              return AppStateScreen.setupRequired(
+                onSetup: () => context.go('/setup'),
+                body:
+                    'Sisesta sissetulek, püsikulud ja kategooriad, et avaleht saaks sinu kuu ülevaate arvutada.',
+              );
             }
 
             final summary = summaryState.summary!;
@@ -99,7 +105,7 @@ class HomeScreen extends ConsumerWidget {
                         const SizedBox(height: 12),
                         ref.watch(remoteInsightProvider).when(
                           loading: () => HomeInsightCard(insight: summary.insight),
-                          error: (e, _) => Text('REMOTE VIGA: $e'),
+                          error: (e, st) => HomeInsightCard(insight: summary.insight),
                           data: (remote) => remote != null
                               ? RemoteInsightCard(insight: remote)
                               : HomeInsightCard(insight: summary.insight),

--- a/lib/features/purchase_check/presentation/purchase_check_screen.dart
+++ b/lib/features/purchase_check/presentation/purchase_check_screen.dart
@@ -1,9 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../../app/theme/app_colors.dart';
-import '../../../app/theme/app_spacing.dart';
+import '../../../shared/widgets/app_state_screen.dart';
 import '../../setup/domain/models/budget_category.dart';
 import '../domain/models/purchase_check_result.dart';
 import '../domain/models/purchase_risk_status.dart';
@@ -34,27 +35,23 @@ class _PurchaseCheckScreenState extends ConsumerState<PurchaseCheckScreen> {
       backgroundColor: AppColors.background,
       body: SafeArea(
         child: checkAsync.when(
-          loading: () =>
-              const Center(child: CircularProgressIndicator()),
-          error: (e, _) => _EmptyLayout(
-            icon: Icons.error_outline,
-            title: 'Midagi läks valesti',
-            message: e.toString(),
+          loading: () => AppStateScreen.loading(),
+          error: (e, _) => AppStateScreen.error(
+            onRetry: () => ref.invalidate(purchaseCheckProvider),
           ),
           data: (state) {
             if (!state.isConfigured) {
-              return const _EmptyLayout(
-                icon: Icons.tune_outlined,
-                title: 'Seadistus puudub',
-                message:
-                    'Ostu hindamiseks lõpeta esmalt eelarve seadistamine.',
+              return AppStateScreen.setupRequired(
+                onSetup: () => context.go('/setup'),
+                body:
+                    'Ostu hindamiseks sisesta esmalt kuine eelarve alus.',
               );
             }
             if (!state.hasCategories) {
-              return const _EmptyLayout(
-                icon: Icons.category_outlined,
+              return AppStateScreen.setupRequired(
+                onSetup: () => context.go('/setup'),
                 title: 'Kategooriaid pole',
-                message:
+                body:
                     'Lisa seadistuses kulukategooriad, et ostu hinnata.',
               );
             }
@@ -579,58 +576,6 @@ class _ErrorBanner extends StatelessWidget {
   }
 }
 
-// ── Empty / missing-data state ────────────────────────────────────────────────
-
-class _EmptyLayout extends StatelessWidget {
-  const _EmptyLayout({
-    required this.icon,
-    required this.title,
-    required this.message,
-  });
-
-  final IconData icon;
-  final String title;
-  final String message;
-
-  @override
-  Widget build(BuildContext context) {
-    return Center(
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 40),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Container(
-              padding: const EdgeInsets.all(20),
-              decoration: const BoxDecoration(
-                color: AppColors.inputFill,
-                shape: BoxShape.circle,
-              ),
-              child: Icon(icon, size: 36, color: AppColors.textSecondary),
-            ),
-            const SizedBox(height: AppSpacing.lg),
-            Text(
-              title,
-              style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                    fontWeight: FontWeight.w700,
-                    color: AppColors.textPrimary,
-                  ),
-              textAlign: TextAlign.center,
-            ),
-            const SizedBox(height: AppSpacing.sm),
-            Text(
-              message,
-              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                    color: AppColors.textSecondary,
-                  ),
-              textAlign: TextAlign.center,
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
 
 // ── Status theming ────────────────────────────────────────────────────────────
 

--- a/lib/features/settings/presentation/settings_screen.dart
+++ b/lib/features/settings/presentation/settings_screen.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../../app/theme/app_colors.dart';
+import '../../../shared/widgets/app_state_screen.dart';
 import '../../../features/setup/domain/models/budget_category.dart';
 import 'providers/settings_notifier.dart';
 import 'providers/settings_state.dart';
@@ -83,45 +85,44 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
         ),
       ),
       body: state.isLoading
-          ? const Center(child: CircularProgressIndicator())
-          : Column(
-              children: [
-                Expanded(
-                  child: ListView(
-                    padding: const EdgeInsets.fromLTRB(20, 16, 20, 8),
-                    children: [
-                      if (!state.hasProfile) ...[
-                        _NoProfileBanner(),
-                        const SizedBox(height: 24),
-                      ],
-                      if (state.hasProfile) ...[
-                        _sectionLabel('Eelarve seaded'),
-                        const SizedBox(height: 12),
-                        _BudgetSettingsCard(
-                            state: state, notifier: notifier),
-                        const SizedBox(height: 24),
-                        _CategorySectionHeader(state: state),
-                        const SizedBox(height: 12),
-                        _CategoryListCard(
-                            state: state, notifier: notifier),
-                        const SizedBox(height: 8),
-                        _AddCategoryButton(notifier: notifier),
-                        const SizedBox(height: 24),
-                      ],
-                      _sectionLabel('Eelistused'),
-                      const SizedBox(height: 12),
-                      _NotificationsCard(
-                          state: state, notifier: notifier),
-                      const SizedBox(height: 24),
-                      _DataSecurityCard(),
-                      const SizedBox(height: 8),
-                    ],
-                  ),
+          ? AppStateScreen.loading()
+          : !state.hasProfile
+              ? AppStateScreen.setupRequired(
+                  onSetup: () => context.go('/setup'),
+                  body:
+                      'Seadete kasutamiseks sisesta esmalt eelarve alus — sissetulek, püsikulud ja kategooriad.',
+                )
+              : Column(
+                  children: [
+                    Expanded(
+                      child: ListView(
+                        padding: const EdgeInsets.fromLTRB(20, 16, 20, 8),
+                        children: [
+                          _sectionLabel('Eelarve seaded'),
+                          const SizedBox(height: 12),
+                          _BudgetSettingsCard(
+                              state: state, notifier: notifier),
+                          const SizedBox(height: 24),
+                          _CategorySectionHeader(state: state),
+                          const SizedBox(height: 12),
+                          _CategoryListCard(
+                              state: state, notifier: notifier),
+                          const SizedBox(height: 8),
+                          _AddCategoryButton(notifier: notifier),
+                          const SizedBox(height: 24),
+                          _sectionLabel('Eelistused'),
+                          const SizedBox(height: 12),
+                          _NotificationsCard(
+                              state: state, notifier: notifier),
+                          const SizedBox(height: 24),
+                          _DataSecurityCard(),
+                          const SizedBox(height: 8),
+                        ],
+                      ),
+                    ),
+                    _SaveButton(state: state, notifier: notifier),
+                  ],
                 ),
-                if (state.hasProfile)
-                  _SaveButton(state: state, notifier: notifier),
-              ],
-            ),
     );
   }
 
@@ -141,7 +142,6 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   }
 }
 
-// ── Eelarve seaded card ────────────────────────────────────────────────────────
 
 class _BudgetSettingsCard extends StatelessWidget {
   final SettingsState state;
@@ -242,7 +242,6 @@ class _BudgetSettingsCard extends StatelessWidget {
   }
 }
 
-// ── Category section header ────────────────────────────────────────────────────
 
 class _CategorySectionHeader extends StatelessWidget {
   final SettingsState state;
@@ -292,7 +291,6 @@ class _CategorySectionHeader extends StatelessWidget {
   }
 }
 
-// ── Category list card ────────────────────────────────────────────────────────
 
 class _CategoryListCard extends StatelessWidget {
   final SettingsState state;
@@ -316,7 +314,6 @@ class _CategoryListCard extends StatelessWidget {
       ]);
     }
 
-    // Build color opacities for segmented bar
     final opacities = [1.0, 0.65, 0.45, 0.28, 0.15];
 
     return _Card(
@@ -353,7 +350,6 @@ class _CategoryListCard extends StatelessWidget {
     final nameCtrl = TextEditingController(text: category.name);
     double localPercent = category.allocationPercent;
 
-    // Max = current + unallocated
     final maxPercent =
         category.allocationPercent + state.unallocatedPercent;
 
@@ -610,7 +606,6 @@ class _AllocationBar extends StatelessWidget {
   }
 }
 
-// ── Add category button ────────────────────────────────────────────────────────
 
 class _AddCategoryButton extends StatelessWidget {
   final SettingsNotifier notifier;
@@ -707,7 +702,6 @@ class _AddCategoryButton extends StatelessWidget {
   }
 }
 
-// ── Notifications card ────────────────────────────────────────────────────────
 
 class _NotificationsCard extends StatelessWidget {
   final SettingsState state;
@@ -765,7 +759,6 @@ class _NotificationsCard extends StatelessWidget {
   }
 }
 
-// ── Data security card ────────────────────────────────────────────────────────
 
 class _DataSecurityCard extends StatelessWidget {
   @override
@@ -828,40 +821,6 @@ class _DataSecurityCard extends StatelessWidget {
   }
 }
 
-// ── No profile banner ─────────────────────────────────────────────────────────
-
-class _NoProfileBanner extends StatelessWidget {
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.all(16),
-      decoration: BoxDecoration(
-        color: AppColors.warningBg,
-        borderRadius: BorderRadius.circular(14),
-        border: Border.all(
-            color: AppColors.warning.withValues(alpha: 0.3)),
-      ),
-      child: const Row(
-        children: [
-          Icon(Icons.info_outline, color: AppColors.warning, size: 20),
-          SizedBox(width: 12),
-          Expanded(
-            child: Text(
-              'Eelarve profiil puudub. Seadistage rakendus esmalt.',
-              style: TextStyle(
-                color: AppColors.warning,
-                fontSize: 13,
-                fontWeight: FontWeight.w500,
-              ),
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-// ── Save button (pinned above nav) ────────────────────────────────────────────
 
 class _SaveButton extends StatelessWidget {
   final SettingsState state;
@@ -908,7 +867,6 @@ class _SaveButton extends StatelessWidget {
   }
 }
 
-// ── Shared primitives ─────────────────────────────────────────────────────────
 
 class _Card extends StatelessWidget {
   final List<Widget> children;

--- a/lib/shared/widgets/app_state_screen.dart
+++ b/lib/shared/widgets/app_state_screen.dart
@@ -1,0 +1,177 @@
+import 'package:flutter/material.dart';
+
+import '../../app/theme/app_colors.dart';
+import '../../app/theme/app_spacing.dart';
+
+/// Shared full-screen state widget for loading, error, empty, and setup-required states.
+///
+/// Use the static factory methods for common cases:
+///   AppStateScreen.loading()
+///   AppStateScreen.error(message: '...', onRetry: () => ...)
+///   AppStateScreen.empty(title: '...', body: '...')
+///   AppStateScreen.setupRequired(onSetup: () => ...)
+///
+/// The [setupRequired] variant is visually distinct: the icon uses the primary
+/// teal colour and always renders a primary CTA button, signalling that the
+/// missing state is a prerequisite rather than an error or data gap.
+class AppStateScreen extends StatelessWidget {
+  const AppStateScreen._loading()
+      : _showLoading = true,
+        icon = null,
+        title = '',
+        body = null,
+        iconColor = null,
+        iconBackground = null,
+        actionLabel = null,
+        onAction = null;
+
+  const AppStateScreen({
+    super.key,
+    this.icon,
+    required this.title,
+    this.body,
+    this.iconColor,
+    this.iconBackground,
+    this.actionLabel,
+    this.onAction,
+  }) : _showLoading = false;
+
+  final bool _showLoading;
+  final IconData? icon;
+  final String title;
+  final String? body;
+  final Color? iconColor;
+  final Color? iconBackground;
+  final String? actionLabel;
+  final VoidCallback? onAction;
+
+  // ── Named factory constructors ────────────────────────────────────────────
+
+  /// Calm centered loading spinner.
+  static AppStateScreen loading() => const AppStateScreen._loading();
+
+  /// Error state with optional retry action.
+  static AppStateScreen error({
+    String message = 'Andmete laadimine ebaõnnestus.',
+    VoidCallback? onRetry,
+  }) =>
+      AppStateScreen(
+        icon: Icons.error_outline_rounded,
+        title: 'Midagi läks valesti',
+        body: message,
+        iconColor: AppColors.error,
+        iconBackground: AppColors.errorBg,
+        actionLabel: onRetry != null ? 'Proovi uuesti' : null,
+        onAction: onRetry,
+      );
+
+  /// Generic empty/no-data state.
+  static AppStateScreen empty({
+    required String title,
+    required String body,
+    IconData icon = Icons.inbox_outlined,
+  }) =>
+      AppStateScreen(
+        icon: icon,
+        title: title,
+        body: body,
+        iconColor: AppColors.textSecondary,
+        iconBackground: AppColors.inputFill,
+      );
+
+  /// Setup-required state — visually distinct from plain empty.
+  ///
+  /// Uses the primary teal colour and always shows a CTA button leading to setup.
+  static AppStateScreen setupRequired({
+    required VoidCallback onSetup,
+    String title = 'Seadistus puudub',
+    String body =
+        'Selle vaate kasutamiseks sisesta esmalt kuine eelarve alus.',
+  }) =>
+      AppStateScreen(
+        icon: Icons.account_balance_wallet_outlined,
+        title: title,
+        body: body,
+        iconColor: AppColors.primary,
+        iconBackground: AppColors.primarySoft,
+        actionLabel: 'Ava seadistus',
+        onAction: onSetup,
+      );
+
+  // ── Build ─────────────────────────────────────────────────────────────────
+
+  @override
+  Widget build(BuildContext context) {
+    if (_showLoading) {
+      return const Center(
+        child: CircularProgressIndicator(
+          color: AppColors.primary,
+          strokeWidth: 2.5,
+        ),
+      );
+    }
+
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 40),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (icon != null) ...[
+              Container(
+                padding: const EdgeInsets.all(20),
+                decoration: BoxDecoration(
+                  color: iconBackground ?? AppColors.inputFill,
+                  shape: BoxShape.circle,
+                ),
+                child: Icon(
+                  icon,
+                  size: 32,
+                  color: iconColor ?? AppColors.textSecondary,
+                ),
+              ),
+              const SizedBox(height: AppSpacing.lg),
+            ],
+            Text(
+              title,
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.w700,
+                    color: AppColors.textPrimary,
+                  ),
+              textAlign: TextAlign.center,
+            ),
+            if (body != null) ...[
+              const SizedBox(height: AppSpacing.sm),
+              Text(
+                body!,
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      color: AppColors.textSecondary,
+                    ),
+                textAlign: TextAlign.center,
+              ),
+            ],
+            if (onAction != null && actionLabel != null) ...[
+              const SizedBox(height: AppSpacing.xl),
+              FilledButton(
+                onPressed: onAction,
+                style: FilledButton.styleFrom(
+                  backgroundColor: AppColors.primary,
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 24,
+                    vertical: 14,
+                  ),
+                  shape: const StadiumBorder(),
+                  elevation: 0,
+                ),
+                child: Text(
+                  actionLabel!,
+                  style: const TextStyle(fontWeight: FontWeight.w600),
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Closes #19 

Standardized loading, error, and empty states across the main screens so the app feels much more consistent and polished. Also separated the missing setup state from generic empty states and cleaned up the Estonian copy so broken or incomplete situations feel intentional instead of unfinished.